### PR TITLE
Update the dependency-management-plugin to work with Gradle 2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
         classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.8'
-        classpath 'io.spring.gradle:dependency-management-plugin:0.5.1.RELEASE'
+        classpath 'io.spring.gradle:dependency-management-plugin:0.5.3.RELEASE'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
         classpath 'org.asciidoctor:asciidoctorj:1.5.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'


### PR DESCRIPTION
There's a breaking change in Gradle 2.5 and it won't work with the dependency-management-plugin 0.5.1.RELEASE See: https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/54

I have updated the dependency-management.plugin to 0.5.3.RELEASE