### PR TITLE
Do not render URI scheme if none of host, schemes or basePath are set

### DIFF
--- a/src/main/java/io/github/robwin/swagger2markup/builder/document/OverviewDocument.java
+++ b/src/main/java/io/github/robwin/swagger2markup/builder/document/OverviewDocument.java
@@ -105,22 +105,23 @@ public class OverviewDocument extends MarkupDocument {
             this.markupDocBuilder.newLine();
         }
 
-        this.markupDocBuilder.sectionTitleLevel2(URI_SCHEME);
-        if(StringUtils.isNotBlank(swagger.getHost())){
-            this.markupDocBuilder.textLine(HOST + swagger.getHost());
-        }
-        if(StringUtils.isNotBlank(swagger.getBasePath())){
-            this.markupDocBuilder.textLine(BASE_PATH + swagger.getBasePath());
-        }
-        if(CollectionUtils.isNotEmpty(swagger.getSchemes())){
-            List<String> schemes = new ArrayList<>();
-            for(Scheme scheme : swagger.getSchemes()){
-                schemes.add(scheme.toString());
+        if(StringUtils.isNotBlank(swagger.getHost()) || StringUtils.isNotBlank(swagger.getBasePath()) || CollectionUtils.isNotEmpty(swagger.getSchemes())) {
+            this.markupDocBuilder.sectionTitleLevel2(URI_SCHEME);
+            if (StringUtils.isNotBlank(swagger.getHost())) {
+                this.markupDocBuilder.textLine(HOST + swagger.getHost());
             }
-            this.markupDocBuilder.textLine(SCHEMES + StringUtils.join(schemes, ", "));
-
+            if (StringUtils.isNotBlank(swagger.getBasePath())) {
+                this.markupDocBuilder.textLine(BASE_PATH + swagger.getBasePath());
+            }
+            if (CollectionUtils.isNotEmpty(swagger.getSchemes())) {
+                List<String> schemes = new ArrayList<>();
+                for (Scheme scheme : swagger.getSchemes()) {
+                    schemes.add(scheme.toString());
+                }
+                this.markupDocBuilder.textLine(SCHEMES + StringUtils.join(schemes, ", "));
+            }
+            this.markupDocBuilder.newLine();
         }
-        this.markupDocBuilder.newLine();
 
         if(CollectionUtils.isNotEmpty(swagger.getTags())){
             this.markupDocBuilder.sectionTitleLevel2(TAGS);

--- a/src/test/java/io/github/robwin/swagger2markup/Swagger2MarkupConverterTest.java
+++ b/src/test/java/io/github/robwin/swagger2markup/Swagger2MarkupConverterTest.java
@@ -92,6 +92,44 @@ public class Swagger2MarkupConverterTest {
     }
 
     @Test
+    public void testSwagger2AsciiDocConversionDoesNotContainUriScheme() throws IOException {
+        //Given
+        File file = new File(Swagger2MarkupConverterTest.class.getResource("/yaml/swagger_should_not_contain_uri_scheme.yaml").getFile());
+        File outputDirectory = new File("build/docs/asciidoc/generated");
+        FileUtils.deleteQuietly(outputDirectory);
+
+        //When
+        Swagger2MarkupConverter.from(file.getAbsolutePath()).build()
+                .intoFolder(outputDirectory.getAbsolutePath());
+
+        //Then
+        String[] directories = outputDirectory.list();
+        assertThat(directories).hasSize(3).containsAll(asList("definitions.adoc", "overview.adoc", "paths.adoc"));
+
+        assertThat(new String(Files.readAllBytes(Paths.get(outputDirectory + File.separator + "overview.adoc"))))
+                .doesNotContain("=== URI scheme");
+    }
+
+    @Test
+    public void testSwagger2AsciiDocConversionContainsUriScheme() throws IOException {
+        //Given
+        File file = new File(Swagger2MarkupConverterTest.class.getResource("/yaml/swagger_should_contain_uri_scheme.yaml").getFile());
+        File outputDirectory = new File("build/docs/asciidoc/generated");
+        FileUtils.deleteQuietly(outputDirectory);
+
+        //When
+        Swagger2MarkupConverter.from(file.getAbsolutePath()).build()
+                .intoFolder(outputDirectory.getAbsolutePath());
+
+        //Then
+        String[] directories = outputDirectory.list();
+        assertThat(directories).hasSize(3).containsAll(asList("definitions.adoc", "overview.adoc", "paths.adoc"));
+
+        assertThat(new String(Files.readAllBytes(Paths.get(outputDirectory + File.separator + "overview.adoc"))))
+                .contains("=== URI scheme");
+    }
+
+    @Test
     public void testSwagger2MarkdownConversion() throws IOException {
         //Given
         File file = new File(Swagger2MarkupConverterTest.class.getResource("/json/swagger.json").getFile());

--- a/src/test/resources/yaml/swagger_should_contain_uri_scheme.yaml
+++ b/src/test/resources/yaml/swagger_should_contain_uri_scheme.yaml
@@ -1,0 +1,21 @@
+swagger: '2.0'
+info:
+  version: "0.0.0"
+  title: Test - Should contain URI scheme
+
+host: localhost
+
+schemes:
+  - http
+  - https
+
+basePath: /api
+
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: string

--- a/src/test/resources/yaml/swagger_should_not_contain_uri_scheme.yaml
+++ b/src/test/resources/yaml/swagger_should_not_contain_uri_scheme.yaml
@@ -1,0 +1,13 @@
+swagger: '2.0'
+info:
+  version: "0.0.0"
+  title: Test - Should not contain URI scheme
+ 
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: string


### PR DESCRIPTION
The URI scheme header should not be rendered if none of host, schemes or basePath are set. Only render it if one or more of the above are used.
