### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencyManagement {
     dependencies {
         dependency "io.github.robwin:markup-document-builder:0.1.6-SNAPSHOT"
         dependency "io.swagger:swagger-compat-spec-parser:1.0.17"
-        dependency "commons-collections:commons-collections:3.2.1"
+        dependency "commons-collections:commons-collections:3.2.2"
         dependency "commons-io:commons-io:2.4"
         dependency "junit:junit:4.11"
         dependency "org.slf4j:slf4j-api:1.7.12"


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/