### PR TITLE
fixing complaints of javadoc about autoclosing tags

### DIFF
--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
@@ -31,7 +31,7 @@ public interface Swagger2MarkupConfig {
     MarkupLanguage getMarkupLanguage();
 
     /**
-     * Specifies the markup language used in Swagger descriptions.<br/>
+     * Specifies the markup language used in Swagger descriptions.<br>
      * By default, {@link io.github.robwin.markup.builder.MarkupLanguage#MARKDOWN} is assumed.
      */
     MarkupLanguage getSwaggerMarkupLanguage();

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupConverter.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupConverter.java
@@ -139,7 +139,7 @@ public class Swagger2MarkupConverter {
     }
 
     /**
-     * Builds the document and stores it in the given {@code outputFile}.<br/>
+     * Builds the document and stores it in the given {@code outputFile}.<br>
      * An extension identifying the markup language will be automatically added to file name.
      *
      * @param outputFile the output file

--- a/src/main/java/io/github/swagger2markup/internal/document/MarkupDocument.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/MarkupDocument.java
@@ -38,7 +38,7 @@ public class MarkupDocument {
     }
 
     /**
-     * Writes the content of the builder to a file.<br/>
+     * Writes the content of the builder to a file.<br>
      * An extension identifying the markup language will be automatically added to file name.
      *
      * @param file    the generated file


### PR DESCRIPTION
Testing it locally gradle's javadoc complained about auto-closing tags that would not be allowed within javadoc. Therefore i removed the autoclosing element.