### PR TITLE
1st column in table extended width in order to avoid text wrapping

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/document/builder/PathsDocumentBuilder.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/builder/PathsDocumentBuilder.java
@@ -82,7 +82,6 @@ public class PathsDocumentBuilder extends MarkupDocumentBuilder {
 
     private static final String PATHS_ANCHOR = "paths";
 
-
     public PathsDocumentBuilder(Swagger2MarkupConverter.Context globalContext, Swagger2MarkupExtensionRegistry extensionRegistry, java.nio.file.Path outputPath) {
         super(globalContext, extensionRegistry, outputPath);
 
@@ -425,9 +424,9 @@ public class PathsDocumentBuilder extends MarkupDocumentBuilder {
         if (hasParameters) {
             List<List<String>> cells = new ArrayList<>();
             List<MarkupTableColumn> cols = Arrays.asList(
-                    new MarkupTableColumn(TYPE_COLUMN).withWidthRatio(3).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^3"),
+                    new MarkupTableColumn(TYPE_COLUMN).withWidthRatio(2).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^2"),
                     new MarkupTableColumn(NAME_COLUMN).withWidthRatio(3).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^3"),
-                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(8).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^8"),
+                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(9).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^9"),
                     new MarkupTableColumn(SCHEMA_COLUMN).withWidthRatio(4).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^4"),
                     new MarkupTableColumn(DEFAULT_COLUMN).withWidthRatio(2).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^2"));
             for (Parameter parameter : parameters) {
@@ -644,8 +643,8 @@ public class PathsDocumentBuilder extends MarkupDocumentBuilder {
         applyPathsDocumentExtension(new Context(Position.OPERATION_RESPONSES_BEGIN, responsesBuilder, operation));
         if (MapUtils.isNotEmpty(responses)) {
             List<MarkupTableColumn> responseCols = Arrays.asList(
-                    new MarkupTableColumn(HTTP_CODE_COLUMN).withWidthRatio(3).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^3"),
-                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(13).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^13"),
+                    new MarkupTableColumn(HTTP_CODE_COLUMN).withWidthRatio(2).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^2"),
+                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(14).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^14"),
                     new MarkupTableColumn(SCHEMA_COLUMN).withWidthRatio(4).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^4"));
 
             List<List<String>> cells = new ArrayList<>();

--- a/src/main/java/io/github/swagger2markup/internal/document/builder/PathsDocumentBuilder.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/builder/PathsDocumentBuilder.java
@@ -425,9 +425,9 @@ public class PathsDocumentBuilder extends MarkupDocumentBuilder {
         if (hasParameters) {
             List<List<String>> cells = new ArrayList<>();
             List<MarkupTableColumn> cols = Arrays.asList(
-                    new MarkupTableColumn(TYPE_COLUMN).withWidthRatio(1).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^1"),
+                    new MarkupTableColumn(TYPE_COLUMN).withWidthRatio(3).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^3"),
                     new MarkupTableColumn(NAME_COLUMN).withWidthRatio(3).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^3"),
-                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(10).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^10"),
+                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(8).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^8"),
                     new MarkupTableColumn(SCHEMA_COLUMN).withWidthRatio(4).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^4"),
                     new MarkupTableColumn(DEFAULT_COLUMN).withWidthRatio(2).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^2"));
             for (Parameter parameter : parameters) {
@@ -644,8 +644,8 @@ public class PathsDocumentBuilder extends MarkupDocumentBuilder {
         applyPathsDocumentExtension(new Context(Position.OPERATION_RESPONSES_BEGIN, responsesBuilder, operation));
         if (MapUtils.isNotEmpty(responses)) {
             List<MarkupTableColumn> responseCols = Arrays.asList(
-                    new MarkupTableColumn(HTTP_CODE_COLUMN).withWidthRatio(1).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^1"),
-                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(15).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^15"),
+                    new MarkupTableColumn(HTTP_CODE_COLUMN).withWidthRatio(3).withHeaderColumn(false).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^3"),
+                    new MarkupTableColumn(DESCRIPTION_COLUMN).withWidthRatio(13).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^13"),
                     new MarkupTableColumn(SCHEMA_COLUMN).withWidthRatio(4).withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^4"));
 
             List<List<String>> cells = new ArrayList<>();

--- a/src/test/resources/expected/asciidoc/default/paths.adoc
+++ b/src/test/resources/expected/asciidoc/default/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -63,7 +63,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -73,7 +73,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -121,7 +121,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -131,7 +131,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -176,7 +176,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -186,7 +186,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -227,7 +227,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -241,7 +241,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -286,7 +286,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -296,7 +296,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -339,7 +339,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -351,7 +351,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -387,7 +387,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -397,7 +397,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -433,7 +433,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -443,7 +443,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -480,7 +480,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -490,7 +490,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -522,7 +522,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -532,7 +532,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -559,7 +559,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -569,7 +569,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -596,7 +596,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -606,7 +606,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -633,7 +633,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -645,7 +645,7 @@ _optional_|The user name for login|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -677,7 +677,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -704,7 +704,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -714,7 +714,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -751,7 +751,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -763,7 +763,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -795,7 +795,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -805,7 +805,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/default/paths.adoc
+++ b/src/test/resources/expected/asciidoc/default/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -63,7 +63,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -73,7 +73,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -121,7 +121,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -131,7 +131,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -176,7 +176,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -186,7 +186,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -227,7 +227,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -241,7 +241,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -286,7 +286,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -296,7 +296,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -339,7 +339,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -351,7 +351,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -387,7 +387,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -397,7 +397,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -433,7 +433,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -443,7 +443,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -480,7 +480,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -490,7 +490,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -522,7 +522,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -532,7 +532,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -559,7 +559,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -569,7 +569,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -596,7 +596,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -606,7 +606,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -633,7 +633,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -645,7 +645,7 @@ _optional_|The user name for login|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -677,7 +677,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -704,7 +704,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -714,7 +714,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -751,7 +751,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -763,7 +763,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -795,7 +795,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -805,7 +805,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/enums/paths.adoc
+++ b/src/test/resources/expected/asciidoc/enums/paths.adoc
@@ -15,7 +15,7 @@ Return state
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*oldState* +
@@ -37,7 +37,7 @@ _optional_|State value|enum (ADDED, REMOVED, CHANGED)
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|enum (ADDED, REMOVED, CHANGED)

--- a/src/test/resources/expected/asciidoc/enums/paths.adoc
+++ b/src/test/resources/expected/asciidoc/enums/paths.adoc
@@ -15,7 +15,7 @@ Return state
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*oldState* +
@@ -37,7 +37,7 @@ _optional_|State value|enum (ADDED, REMOVED, CHANGED)
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|enum (ADDED, REMOVED, CHANGED)

--- a/src/test/resources/expected/asciidoc/examples/paths.adoc
+++ b/src/test/resources/expected/asciidoc/examples/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -80,7 +80,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -90,7 +90,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -138,7 +138,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -148,7 +148,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -189,7 +189,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -199,7 +199,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -236,7 +236,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -250,7 +250,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -295,7 +295,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -305,7 +305,7 @@ _required_|ID of the pet|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_pet,Pet>>
@@ -344,7 +344,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -356,7 +356,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -392,7 +392,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -402,7 +402,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -466,7 +466,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -476,7 +476,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -525,7 +525,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -535,7 +535,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -567,7 +567,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -577,7 +577,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -604,7 +604,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -614,7 +614,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -641,7 +641,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -651,7 +651,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -678,7 +678,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -690,7 +690,7 @@ _optional_|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|string
@@ -718,7 +718,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -745,7 +745,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -755,7 +755,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|`"te
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_user,User>>
@@ -788,7 +788,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -800,7 +800,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -832,7 +832,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -842,7 +842,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/examples/paths.adoc
+++ b/src/test/resources/expected/asciidoc/examples/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -80,7 +80,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -90,7 +90,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -138,7 +138,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -148,7 +148,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -189,7 +189,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -199,7 +199,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -236,7 +236,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -250,7 +250,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -295,7 +295,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -305,7 +305,7 @@ _required_|ID of the pet|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_pet,Pet>>
@@ -344,7 +344,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -356,7 +356,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -392,7 +392,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -402,7 +402,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -466,7 +466,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -476,7 +476,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -525,7 +525,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -535,7 +535,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -567,7 +567,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -577,7 +577,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -604,7 +604,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -614,7 +614,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -641,7 +641,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -651,7 +651,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -678,7 +678,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -690,7 +690,7 @@ _optional_|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|string
@@ -718,7 +718,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -745,7 +745,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -755,7 +755,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|`"te
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_user,User>>
@@ -788,7 +788,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -800,7 +800,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -832,7 +832,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -842,7 +842,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/generated_examples/paths.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -113,7 +113,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -123,7 +123,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -204,7 +204,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -214,7 +214,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -282,7 +282,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -292,7 +292,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -356,7 +356,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -370,7 +370,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -431,7 +431,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -441,7 +441,7 @@ _required_|ID of the pet|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_pet,Pet>>
@@ -515,7 +515,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -527,7 +527,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -579,7 +579,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -589,7 +589,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -660,7 +660,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -670,7 +670,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -728,7 +728,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -738,7 +738,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -779,7 +779,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -789,7 +789,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -842,7 +842,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -852,7 +852,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -905,7 +905,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -915,7 +915,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -968,7 +968,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -980,7 +980,7 @@ _optional_|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|string
@@ -1036,7 +1036,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -1072,7 +1072,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1082,7 +1082,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|`"te
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_user,User>>
@@ -1143,7 +1143,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1155,7 +1155,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -1213,7 +1213,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1223,7 +1223,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/generated_examples/paths.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -113,7 +113,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -123,7 +123,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -204,7 +204,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -214,7 +214,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -282,7 +282,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -292,7 +292,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|< <<_pet,Pet>> > array
@@ -356,7 +356,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -370,7 +370,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -431,7 +431,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -441,7 +441,7 @@ _required_|ID of the pet|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_pet,Pet>>
@@ -515,7 +515,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -527,7 +527,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -579,7 +579,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -589,7 +589,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -660,7 +660,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -670,7 +670,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_order,Order>>
@@ -728,7 +728,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -738,7 +738,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -779,7 +779,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -789,7 +789,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -842,7 +842,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -852,7 +852,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -905,7 +905,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -915,7 +915,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -968,7 +968,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -980,7 +980,7 @@ _optional_|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|string
@@ -1036,7 +1036,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -1072,7 +1072,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1082,7 +1082,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|`"te
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation|<<_user,User>>
@@ -1143,7 +1143,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1155,7 +1155,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -1213,7 +1213,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1223,7 +1223,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/group_by_tags/paths.adoc
+++ b/src/test/resources/expected/asciidoc/group_by_tags/paths.adoc
@@ -16,7 +16,7 @@ POST /pets
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -26,7 +26,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -63,7 +63,7 @@ PUT /pets
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -73,7 +73,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -116,7 +116,7 @@ Multiple status values can be provided with comma seperated strings
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -126,7 +126,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -166,7 +166,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -176,7 +176,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -212,7 +212,7 @@ POST /pets/{petId}
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -226,7 +226,7 @@ _required_|Updated status of the pet|string|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -266,7 +266,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -276,7 +276,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -314,7 +314,7 @@ DELETE /pets/{petId}
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -326,7 +326,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -362,7 +362,7 @@ POST /stores/order
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -372,7 +372,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -403,7 +403,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -413,7 +413,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -445,7 +445,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -455,7 +455,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -487,7 +487,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -497,7 +497,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -519,7 +519,7 @@ POST /users/createWithArray
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -529,7 +529,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -551,7 +551,7 @@ POST /users/createWithList
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -561,7 +561,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -583,7 +583,7 @@ GET /users/login
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -595,7 +595,7 @@ _optional_|The user name for login|string|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -622,7 +622,7 @@ GET /users/logout
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -644,7 +644,7 @@ GET /users/{username}
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -654,7 +654,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -686,7 +686,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -698,7 +698,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -725,7 +725,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -735,7 +735,7 @@ _required_|The name that needs to be deleted|string|
 
 ===== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/group_by_tags/paths.adoc
+++ b/src/test/resources/expected/asciidoc/group_by_tags/paths.adoc
@@ -16,7 +16,7 @@ POST /pets
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -26,7 +26,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -63,7 +63,7 @@ PUT /pets
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -73,7 +73,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -116,7 +116,7 @@ Multiple status values can be provided with comma seperated strings
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -126,7 +126,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -166,7 +166,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -176,7 +176,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -212,7 +212,7 @@ POST /pets/{petId}
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -226,7 +226,7 @@ _required_|Updated status of the pet|string|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -266,7 +266,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -276,7 +276,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -314,7 +314,7 @@ DELETE /pets/{petId}
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -326,7 +326,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -362,7 +362,7 @@ POST /stores/order
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -372,7 +372,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -403,7 +403,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -413,7 +413,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -445,7 +445,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -455,7 +455,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -487,7 +487,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -497,7 +497,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -519,7 +519,7 @@ POST /users/createWithArray
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -529,7 +529,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -551,7 +551,7 @@ POST /users/createWithList
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -561,7 +561,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -583,7 +583,7 @@ GET /users/login
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -595,7 +595,7 @@ _optional_|The user name for login|string|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -622,7 +622,7 @@ GET /users/logout
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -644,7 +644,7 @@ GET /users/{username}
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -654,7 +654,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -686,7 +686,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -698,7 +698,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -725,7 +725,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -735,7 +735,7 @@ _required_|The name that needs to be deleted|string|
 
 ===== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/idxref/paths.adoc
+++ b/src/test/resources/expected/asciidoc/idxref/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<definitions.adoc#_pe
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -63,7 +63,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -73,7 +73,7 @@ _optional_|Pet object that needs to be added to the store|<<definitions.adoc#_pe
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -121,7 +121,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -131,7 +131,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -176,7 +176,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -186,7 +186,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -227,7 +227,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -241,7 +241,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -286,7 +286,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -296,7 +296,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -339,7 +339,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -351,7 +351,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -387,7 +387,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -397,7 +397,7 @@ _optional_|order placed for purchasing the pet|<<definitions.adoc#_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -433,7 +433,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -443,7 +443,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -480,7 +480,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -490,7 +490,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -522,7 +522,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -532,7 +532,7 @@ _optional_|Created user object|<<definitions.adoc#_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -559,7 +559,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -569,7 +569,7 @@ _optional_|List of user object|< <<definitions.adoc#_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -596,7 +596,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -606,7 +606,7 @@ _optional_|List of user object|< <<definitions.adoc#_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -633,7 +633,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -645,7 +645,7 @@ _optional_|The user name for login|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -677,7 +677,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -704,7 +704,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -714,7 +714,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -751,7 +751,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -763,7 +763,7 @@ _optional_|Updated user object|<<definitions.adoc#_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -795,7 +795,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -805,7 +805,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/idxref/paths.adoc
+++ b/src/test/resources/expected/asciidoc/idxref/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -21,7 +21,7 @@ _optional_|Pet object that needs to be added to the store|<<definitions.adoc#_pe
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -63,7 +63,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -73,7 +73,7 @@ _optional_|Pet object that needs to be added to the store|<<definitions.adoc#_pe
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -121,7 +121,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -131,7 +131,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -176,7 +176,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -186,7 +186,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -227,7 +227,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -241,7 +241,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -286,7 +286,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -296,7 +296,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -339,7 +339,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -351,7 +351,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -387,7 +387,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -397,7 +397,7 @@ _optional_|order placed for purchasing the pet|<<definitions.adoc#_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -433,7 +433,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -443,7 +443,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -480,7 +480,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -490,7 +490,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -522,7 +522,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -532,7 +532,7 @@ _optional_|Created user object|<<definitions.adoc#_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -559,7 +559,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -569,7 +569,7 @@ _optional_|List of user object|< <<definitions.adoc#_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -596,7 +596,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -606,7 +606,7 @@ _optional_|List of user object|< <<definitions.adoc#_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -633,7 +633,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -645,7 +645,7 @@ _optional_|The user name for login|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -677,7 +677,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -704,7 +704,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -714,7 +714,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -751,7 +751,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -763,7 +763,7 @@ _optional_|Updated user object|<<definitions.adoc#_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -795,7 +795,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -805,7 +805,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/inline_schema/paths.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema/paths.adoc
@@ -15,7 +15,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*Version* +
@@ -37,7 +37,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|< < string, <<_collectionparameters_post_response_200,Response 200>> > map > array
@@ -74,7 +74,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*Option* +
@@ -126,7 +126,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result +
@@ -182,7 +182,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*Version* +
@@ -224,7 +224,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_mixedparameters_post_response_200,Response 200>>
@@ -281,7 +281,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*Version* +
@@ -323,7 +323,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_result,Result>>

--- a/src/test/resources/expected/asciidoc/inline_schema/paths.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema/paths.adoc
@@ -15,7 +15,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*Version* +
@@ -37,7 +37,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|< < string, <<_collectionparameters_post_response_200,Response 200>> > map > array
@@ -74,7 +74,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*Option* +
@@ -126,7 +126,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result +
@@ -182,7 +182,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*Version* +
@@ -224,7 +224,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_mixedparameters_post_response_200,Response 200>>
@@ -281,7 +281,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*Version* +
@@ -323,7 +323,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_result,Result>>

--- a/src/test/resources/expected/asciidoc/inline_schema_flat_body/paths.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema_flat_body/paths.adoc
@@ -36,7 +36,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|< < string, <<_collectionparameters_post_response_200,Response 200>> > map > array
@@ -73,7 +73,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*Option* +
@@ -129,7 +129,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result +
@@ -223,7 +223,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_mixedparameters_post_response_200,Response 200>>
@@ -318,7 +318,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_result,Result>>

--- a/src/test/resources/expected/asciidoc/inline_schema_flat_body/paths.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema_flat_body/paths.adoc
@@ -36,7 +36,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|< < string, <<_collectionparameters_post_response_200,Response 200>> > map > array
@@ -73,7 +73,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*Option* +
@@ -129,7 +129,7 @@ _optional_|option value|string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result +
@@ -223,7 +223,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_mixedparameters_post_response_200,Response 200>>
@@ -318,7 +318,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|Result|<<_result,Result>>

--- a/src/test/resources/expected/asciidoc/maps/paths.adoc
+++ b/src/test/resources/expected/asciidoc/maps/paths.adoc
@@ -15,7 +15,7 @@ Returns integer metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -25,7 +25,7 @@ _optional_|String metrics|< string, integer(int32) > map|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, string > map
@@ -60,7 +60,7 @@ Returns a collated list of all `@RequestMapping` paths.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -70,7 +70,7 @@ _optional_|Mappings|< string, <<_mappinginfo,MappingInfo>> > map|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, <<_mappinginfo,MappingInfo>> > map
@@ -105,7 +105,7 @@ Returns metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -127,7 +127,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, <<_createmetrics_response_200,Response 200>> > map
@@ -174,7 +174,7 @@ Returns string metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -184,7 +184,7 @@ _optional_|String metrics|< string, string > map|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, string > map

--- a/src/test/resources/expected/asciidoc/maps/paths.adoc
+++ b/src/test/resources/expected/asciidoc/maps/paths.adoc
@@ -15,7 +15,7 @@ Returns integer metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -25,7 +25,7 @@ _optional_|String metrics|< string, integer(int32) > map|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, string > map
@@ -60,7 +60,7 @@ Returns a collated list of all `@RequestMapping` paths.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -70,7 +70,7 @@ _optional_|Mappings|< string, <<_mappinginfo,MappingInfo>> > map|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, <<_mappinginfo,MappingInfo>> > map
@@ -105,7 +105,7 @@ Returns metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -127,7 +127,7 @@ _optional_||string
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, <<_createmetrics_response_200,Response 200>> > map
@@ -174,7 +174,7 @@ Returns string metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -184,7 +184,7 @@ _optional_|String metrics|< string, string > map|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|< string, string > map

--- a/src/test/resources/expected/asciidoc/polymorphism/paths.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphism/paths.adoc
@@ -15,7 +15,7 @@ Get collections
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|<<_collection,Collection>>
@@ -45,7 +45,7 @@ Get pets
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|<<_pet,Pet>>

--- a/src/test/resources/expected/asciidoc/polymorphism/paths.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphism/paths.adoc
@@ -15,7 +15,7 @@ Get collections
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|<<_collection,Collection>>
@@ -45,7 +45,7 @@ Get pets
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|OK|<<_pet,Pet>>

--- a/src/test/resources/expected/asciidoc/response_headers/paths.adoc
+++ b/src/test/resources/expected/asciidoc/response_headers/paths.adoc
@@ -15,7 +15,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -25,7 +25,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +

--- a/src/test/resources/expected/asciidoc/response_headers/paths.adoc
+++ b/src/test/resources/expected/asciidoc/response_headers/paths.adoc
@@ -15,7 +15,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -25,7 +25,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +

--- a/src/test/resources/expected/asciidoc/toFile/outputFile.adoc
+++ b/src/test/resources/expected/asciidoc/toFile/outputFile.adoc
@@ -55,7 +55,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -65,7 +65,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -136,7 +136,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -146,7 +146,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -223,7 +223,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -233,7 +233,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -305,7 +305,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -315,7 +315,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -383,7 +383,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -397,7 +397,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -458,7 +458,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -468,7 +468,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -542,7 +542,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -554,7 +554,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -606,7 +606,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -616,7 +616,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -691,7 +691,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -701,7 +701,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -763,7 +763,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -773,7 +773,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -814,7 +814,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -824,7 +824,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -876,7 +876,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -886,7 +886,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -938,7 +938,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -948,7 +948,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -1000,7 +1000,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -1012,7 +1012,7 @@ _optional_|The user name for login|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -1072,7 +1072,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -1108,7 +1108,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1118,7 +1118,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -1182,7 +1182,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1194,7 +1194,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -1251,7 +1251,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
+[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1261,7 +1261,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^3,.^13,.^4"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/toFile/outputFile.adoc
+++ b/src/test/resources/expected/asciidoc/toFile/outputFile.adoc
@@ -55,7 +55,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -65,7 +65,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -136,7 +136,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -146,7 +146,7 @@ _optional_|Pet object that needs to be added to the store|<<_pet,Pet>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -223,7 +223,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*status* +
@@ -233,7 +233,7 @@ _optional_|Status values that need to be considered for filter|< string > array(
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -305,7 +305,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*tags* +
@@ -315,7 +315,7 @@ _optional_|Tags to filter by|< string > array(multi)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -383,7 +383,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -397,7 +397,7 @@ _required_|Updated status of the pet|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*405*|Invalid input|No Content
@@ -458,7 +458,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*petId* +
@@ -468,7 +468,7 @@ _required_|ID of pet that needs to be fetched|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -542,7 +542,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Header*|*api_key* +
@@ -554,7 +554,7 @@ _required_|Pet id to delete|integer(int64)|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid pet value|No Content
@@ -606,7 +606,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -616,7 +616,7 @@ _optional_|order placed for purchasing the pet|<<_order,Order>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -691,7 +691,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -701,7 +701,7 @@ _required_|ID of pet that needs to be fetched|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -763,7 +763,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*orderId* +
@@ -773,7 +773,7 @@ _required_|ID of the order that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid ID supplied|No Content
@@ -814,7 +814,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -824,7 +824,7 @@ _optional_|Created user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -876,7 +876,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -886,7 +886,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -938,7 +938,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Body*|*body* +
@@ -948,7 +948,7 @@ _optional_|List of user object|< <<_user,User>> > array|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -1000,7 +1000,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Query*|*password* +
@@ -1012,7 +1012,7 @@ _optional_|The user name for login|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -1072,7 +1072,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*default*|successful operation|No Content
@@ -1108,7 +1108,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1118,7 +1118,7 @@ _required_|The name that needs to be fetched. Use user1 for testing.|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*200*|successful operation +
@@ -1182,7 +1182,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1194,7 +1194,7 @@ _optional_|Updated user object|<<_user,User>>|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid user supplied|No Content
@@ -1251,7 +1251,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^1,.^3,.^10,.^4,.^2"]
+[options="header", cols=".^3,.^3,.^8,.^4,.^2"]
 |===
 |Type|Name|Description|Schema|Default
 |*Path*|*username* +
@@ -1261,7 +1261,7 @@ _required_|The name that needs to be deleted|string|
 
 ==== Responses
 
-[options="header", cols=".^1,.^15,.^4"]
+[options="header", cols=".^3,.^13,.^4"]
 |===
 |HTTP Code|Description|Schema
 |*400*|Invalid username supplied|No Content


### PR DESCRIPTION
Hello!

Swagger2Markup version: 1.0.0

Problem description:
Generated Asciidoc files have too narrow columns for 'HTTP Code' (section Responses) and 'Type' (section Parameters). This results in a bit badly generated output in both HTML and PDF. While HTML breaks line after a word (which looks OK), PDF breaks line e.g. HT-TP Cod-e, which does not look good. I have played a bit with the code and changed places where tables are defined. I just extended with on 1st column and respectively narrowed biggest column.

Screenshots below show generated html and pdf _before_ and _after_ modifications:
*#* HTML _before_
![HTML before](https://cloud.githubusercontent.com/assets/10882915/15497780/9748e742-219c-11e6-8dac-b56f828911ae.png)

*#* HTML _after_
![HTML after](https://cloud.githubusercontent.com/assets/10882915/15497774/93310f04-219c-11e6-9928-6d3b8302ac6c.png)

*#* PDF _before_
![PDF before](https://cloud.githubusercontent.com/assets/10882915/15497765/8c2d9c22-219c-11e6-99e5-39377fcda347.png)

*#* PDF _after_
![PDF after](https://cloud.githubusercontent.com/assets/10882915/15497757/831e6224-219c-11e6-937f-f03f6fc92526.png)


