### PR TITLE
new property "pathSecuritySectionEnabled" (default: true)

### DIFF
--- a/src/docs/asciidoc/usage_guide.adoc
+++ b/src/docs/asciidoc/usage_guide.adoc
@@ -141,6 +141,7 @@ The following tables list all available properties of Swagger2Markup:
 |swagger2markup.lineSeparator| Specifies the line separator which should be used | UNIX, WINDOWS, MAC | <System-dependent>
 |swagger2markup.generatedExamplesEnabled| Specifies if HTTP request and response examples should be generated | true, false | false
 |swagger2markup.flatBodyEnabled| Optionally isolate the body parameter, if any, from other parameters | true, false | false
+|swagger2markup.pathSecuritySectionEnabled| Optionally disable the security section for path sections | true, false | true
 |swagger2markup.anchorPrefix| Optionally prefix all anchors for uniqueness if you want to include generated documents into a global documentation | Any String | 
 |===
 

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
@@ -143,6 +143,11 @@ public interface Swagger2MarkupConfig {
      */
     boolean isFlatBodyEnabled();
 
+	/**
+	 * Optionally disable the security section for path sections
+	 */
+	boolean isPathSecuritySectionEnabled();
+
     /**
      * Optionally prefix all anchors for uniqueness.
      */

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
@@ -48,6 +48,7 @@ public class Swagger2MarkupProperties {
     public static final String INTER_DOCUMENT_CROSS_REFERENCES_ENABLED = PROPERTIES_PREFIX + ".interDocumentCrossReferencesEnabled";
     public static final String INTER_DOCUMENT_CROSS_REFERENCES_PREFIX = PROPERTIES_PREFIX + ".interDocumentCrossReferencesPrefix";
     public static final String FLAT_BODY_ENABLED = PROPERTIES_PREFIX + ".flatBodyEnabled";
+	public static final String PATH_SECURITY_SECTION_ENABLED = PROPERTIES_PREFIX + ".pathSecuritySectionEnabled";
     public static final String ANCHOR_PREFIX = PROPERTIES_PREFIX + ".anchorPrefix";
     public static final String OVERVIEW_DOCUMENT = PROPERTIES_PREFIX + ".overviewDocument";
     public static final String PATHS_DOCUMENT = PROPERTIES_PREFIX + ".pathsDocument";

--- a/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
+++ b/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
@@ -109,6 +109,7 @@ public class Swagger2MarkupConfigBuilder  {
         config.interDocumentCrossReferencesEnabled = swagger2MarkupProperties.getRequiredBoolean(INTER_DOCUMENT_CROSS_REFERENCES_ENABLED);
         config.interDocumentCrossReferencesPrefix = swagger2MarkupProperties.getString(INTER_DOCUMENT_CROSS_REFERENCES_PREFIX, null);
         config.flatBodyEnabled = swagger2MarkupProperties.getRequiredBoolean(FLAT_BODY_ENABLED);
+		config.pathSecuritySectionEnabled = swagger2MarkupProperties.getRequiredBoolean(PATH_SECURITY_SECTION_ENABLED);
         config.anchorPrefix = swagger2MarkupProperties.getString(ANCHOR_PREFIX, null);
         config.overviewDocument = swagger2MarkupProperties.getRequiredString(OVERVIEW_DOCUMENT);
         config.pathsDocument = swagger2MarkupProperties.getRequiredString(PATHS_DOCUMENT);
@@ -467,6 +468,16 @@ public class Swagger2MarkupConfigBuilder  {
     }
 
     /**
+	 * Optionally disable the security section for path sections
+	 *
+	 * @return this builder
+	 */
+	public Swagger2MarkupConfigBuilder withoutPathSecuritySection() {
+		config.pathSecuritySectionEnabled = false;
+		return this;
+	}
+	
+    /**
      * Optionally prefix all anchors for uniqueness.
      *
      * @param anchorPrefix anchor prefix.
@@ -515,6 +526,7 @@ public class Swagger2MarkupConfigBuilder  {
         private boolean interDocumentCrossReferencesEnabled;
         private String interDocumentCrossReferencesPrefix;
         private boolean flatBodyEnabled;
+		private boolean pathSecuritySectionEnabled;
         private String anchorPrefix;
         private LineSeparator lineSeparator;
 
@@ -641,6 +653,11 @@ public class Swagger2MarkupConfigBuilder  {
         public boolean isFlatBodyEnabled() {
             return flatBodyEnabled;
         }
+
+		@Override
+		public boolean isPathSecuritySectionEnabled() {
+			return pathSecuritySectionEnabled;
+		}
 
         @Override
         public String getAnchorPrefix() {

--- a/src/main/java/io/github/swagger2markup/internal/document/builder/PathsDocumentBuilder.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/builder/PathsDocumentBuilder.java
@@ -277,7 +277,9 @@ public class PathsDocumentBuilder extends MarkupDocumentBuilder {
             buildConsumesSection(operation, docBuilder);
             buildProducesSection(operation, docBuilder);
             buildTagsSection(operation, docBuilder);
-            buildSecuritySchemeSection(operation, docBuilder);
+            if (config.isPathSecuritySectionEnabled()) {
+            	buildSecuritySchemeSection(operation, docBuilder);
+            }
             buildExamplesSection(operation, docBuilder);
             applyPathsDocumentExtension(new Context(Position.OPERATION_END, docBuilder, operation));
             applyPathsDocumentExtension(new Context(Position.OPERATION_AFTER, docBuilder, operation));

--- a/src/main/resources/io/github/swagger2markup/config/default.properties
+++ b/src/main/resources/io/github/swagger2markup/config/default.properties
@@ -10,6 +10,7 @@ swagger2markup.outputLanguage=EN
 swagger2markup.inlineSchemaEnabled=true
 swagger2markup.interDocumentCrossReferencesEnabled=false
 swagger2markup.flatBodyEnabled=false
+swagger2markup.pathSecuritySectionEnabled=true
 swagger2markup.overviewDocument=overview
 swagger2markup.pathsDocument=paths
 swagger2markup.definitionsDocument=definitions

--- a/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
+++ b/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
@@ -67,6 +67,7 @@ public class Swagger2MarkupConfigBuilderTest {
         assertThat(config.getTagOrderBy()).isEqualTo(OrderBy.NATURAL);
         assertThat(config.getTagOrdering()).isEqualTo(Ordering.natural());
         assertThat(config.isFlatBodyEnabled()).isFalse();
+        assertThat(config.isPathSecuritySectionEnabled()).isTrue();
         assertThat(config.isInterDocumentCrossReferencesEnabled()).isFalse();
         assertThat(config.isSeparatedDefinitionsEnabled()).isFalse();
         assertThat(config.isSeparatedOperationsEnabled()).isFalse();
@@ -111,6 +112,7 @@ public class Swagger2MarkupConfigBuilderTest {
         assertThat(config.getTagOrderBy()).isEqualTo(OrderBy.AS_IS);
         assertThat(config.getTagOrdering()).isNull();
         assertThat(config.isFlatBodyEnabled()).isTrue();
+        assertThat(config.isPathSecuritySectionEnabled()).isFalse();
         assertThat(config.isInterDocumentCrossReferencesEnabled()).isTrue();
         assertThat(config.isSeparatedDefinitionsEnabled()).isTrue();
         assertThat(config.isSeparatedOperationsEnabled()).isTrue();

--- a/src/test/resources/config/config.properties
+++ b/src/test/resources/config/config.properties
@@ -8,6 +8,7 @@ swagger2markup.inlineSchemaEnabled=false
 swagger2markup.interDocumentCrossReferencesEnabled=true
 swagger2markup.interDocumentCrossReferencesPrefix=xrefPrefix
 swagger2markup.flatBodyEnabled=true
+swagger2markup.pathSecuritySectionEnabled=false
 swagger2markup.anchorPrefix=anchorPrefix
 swagger2markup.overviewDocument=overviewTest
 swagger2markup.pathsDocument=pathsTest


### PR DESCRIPTION
As discussed in Gerrit, this change adds a new property "pathSecuritySectionEnabled" (default: true) to optionally disable the security section for every path element.

The main reason for this option is that the table in the section can grow large and doesn't provide useful information if it always looks the same (my example requires some HTTP Headers for authentication which are repeated over and over for every path)