### PR TITLE
Updated min/max value to format correctly based on the data type

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/document/builder/MarkupDocumentBuilder.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/builder/MarkupDocumentBuilder.java
@@ -210,8 +210,8 @@ public abstract class MarkupDocumentBuilder {
                 Integer maxlength = PropertyUtils.getMaxlength(property);
                 Integer minlength = PropertyUtils.getMinlength(property);
                 String pattern = PropertyUtils.getPattern(property);
-                Double minValue = PropertyUtils.getMin(property);
-                Double maxValue = PropertyUtils.getMax(property);
+                Number minValue = PropertyUtils.getMin(property);
+                Number maxValue = PropertyUtils.getMax(property);
 
                 MarkupDocBuilder propertyNameContent = copyMarkupDocBuilder();
                 propertyNameContent.boldTextLine(propertyName, true);

--- a/src/main/java/io/github/swagger2markup/internal/utils/PropertyUtils.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/PropertyUtils.java
@@ -185,22 +185,16 @@ public final class PropertyUtils {
      * @param property the property
      * @return the minimum value of the property, or otherwise null
      */
-    public static Double getMin(Property property) {
+    public static Number getMin(Property property) {
         Validate.notNull(property, "property must not be null");
-        Double min = null;
-        
-        if (property instanceof DoubleProperty) {
-            DoubleProperty doubleProperty = (DoubleProperty) property;
-            min = doubleProperty.getMinimum();
-        } else if (property instanceof FloatProperty) {
-            FloatProperty floatProperty = (FloatProperty) property;
-            min = floatProperty.getMinimum();
-        } else if (property instanceof IntegerProperty) {
-            IntegerProperty integerProperty = (IntegerProperty) property;
-            min = integerProperty.getMinimum();
-        } else if (property instanceof LongProperty) {
-            LongProperty longProperty = (LongProperty) property;
-            min = longProperty.getMinimum();
+        Number min = null;
+
+        if (property instanceof BaseIntegerProperty){
+            BaseIntegerProperty integerProperty = (BaseIntegerProperty) property;
+            min = integerProperty.getMinimum() != null ? integerProperty.getMinimum().longValue() : null;
+        } else if (property instanceof AbstractNumericProperty){
+            AbstractNumericProperty numericProperty = (AbstractNumericProperty) property;
+            min = numericProperty.getMinimum();
         }
         return min;
     }
@@ -211,22 +205,16 @@ public final class PropertyUtils {
      * @param property the property
      * @return the minimum value of the property, or otherwise null
      */
-    public static Double getMax(Property property) {
+    public static Number getMax(Property property) {
         Validate.notNull(property, "property must not be null");
-        Double max = null;
-        
-        if (property instanceof DoubleProperty) {
-            DoubleProperty doubleProperty = (DoubleProperty) property;
-            max = doubleProperty.getMaximum();
-        } else if (property instanceof FloatProperty) {
-            FloatProperty floatProperty = (FloatProperty) property;
-            max = floatProperty.getMaximum();
-        } else if (property instanceof IntegerProperty) {
-            IntegerProperty integerProperty = (IntegerProperty) property;
-            max = integerProperty.getMaximum();
-        } else if (property instanceof LongProperty) {
-            LongProperty longProperty = (LongProperty) property;
-            max = longProperty.getMaximum();
+        Number max = null;
+
+        if (property instanceof BaseIntegerProperty){
+            BaseIntegerProperty integerProperty = (BaseIntegerProperty) property;
+            max = integerProperty.getMaximum() != null ? integerProperty.getMaximum().longValue() : null;
+        } else if (property instanceof AbstractNumericProperty){
+            AbstractNumericProperty numericProperty = (AbstractNumericProperty) property;
+            max = numericProperty.getMaximum();
         }
         return max;
     }

--- a/src/test/resources/expected/asciidoc/default/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/default/definitions.adoc
@@ -33,8 +33,8 @@ _optional_||integer(int64)
 _optional_||integer(int64)
 |*quantity* +
 _optional_|*Default* : `0` +
-*Minimum value* : `0.0` +
-*Maximum value* : `10000.0` +
+*Minimum value* : `0` +
+*Maximum value* : `10000` +
 *Example* : `10`|integer(int32)
 |*shipDate* +
 _optional_||string(date-time)

--- a/src/test/resources/expected/asciidoc/group_by_tags/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/group_by_tags/definitions.adoc
@@ -33,8 +33,8 @@ _optional_||integer(int64)
 _optional_||integer(int64)
 |*quantity* +
 _optional_|*Default* : `0` +
-*Minimum value* : `0.0` +
-*Maximum value* : `10000.0` +
+*Minimum value* : `0` +
+*Maximum value* : `10000` +
 *Example* : `10`|integer(int32)
 |*shipDate* +
 _optional_||string(date-time)

--- a/src/test/resources/expected/asciidoc/idxref/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/idxref/definitions.adoc
@@ -33,8 +33,8 @@ _optional_||integer(int64)
 _optional_||integer(int64)
 |*quantity* +
 _optional_|*Default* : `0` +
-*Minimum value* : `0.0` +
-*Maximum value* : `10000.0` +
+*Minimum value* : `0` +
+*Maximum value* : `10000` +
 *Example* : `10`|integer(int32)
 |*shipDate* +
 _optional_||string(date-time)

--- a/src/test/resources/expected/asciidoc/polymorphism/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphism/definitions.adoc
@@ -75,7 +75,7 @@ _required_||string
 |*packSize* +
 _required_|the size of the pack the dog is from +
 *Default* : `0` +
-*Minimum value* : `0.0`|integer(int32)
+*Minimum value* : `0`|integer(int32)
 |*petType* +
 _required_||string
 |===

--- a/src/test/resources/expected/asciidoc/polymorphismAsIsOrdering/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphismAsIsOrdering/definitions.adoc
@@ -77,7 +77,7 @@ _required_||string
 |*packSize* +
 _required_|the size of the pack the dog is from +
 *Default* : `0` +
-*Minimum value* : `0.0`|integer(int32)
+*Minimum value* : `0`|integer(int32)
 |===
 
 

--- a/src/test/resources/expected/asciidoc/toFile/outputFile.adoc
+++ b/src/test/resources/expected/asciidoc/toFile/outputFile.adoc
@@ -1325,8 +1325,8 @@ _optional_|*Example* : `0`|integer(int64)
 _optional_|*Example* : `0`|integer(int64)
 |*quantity* +
 _optional_|*Default* : `0` +
-*Minimum value* : `0.0` +
-*Maximum value* : `10000.0` +
+*Minimum value* : `0` +
+*Maximum value* : `10000` +
 *Example* : `10`|integer(int32)
 |*shipDate* +
 _optional_|*Example* : `"string"`|string(date-time)

--- a/src/test/resources/expected/asciidoc/validators/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/validators/definitions.adoc
@@ -8,19 +8,32 @@
 [options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
+|*sampleDoubleComplete* +
+_optional_|sample double with range 0.0-10.0 +
+*Minimum value* : `0.0` +
+*Maximum value* : `10.0`|number(double)
+|*sampleDoubleNoDescription* +
+_optional_|*Minimum value* : `0.0` +
+*Maximum value* : `10.0`|number(double)
+|*sampleDoubleOnlyMaximum* +
+_optional_|sample double with range to 10.0 +
+*Maximum value* : `10.0`|number(double)
+|*sampleDoubleOnlyMinimum* +
+_optional_|sample double with range from 0.0 +
+*Minimum value* : `0.0`|number(double)
 |*sampleNumberComplete* +
 _optional_|sample int with range 0-10 +
-*Minimum value* : `0.0` +
-*Maximum value* : `10.0`|integer(int32)
+*Minimum value* : `0` +
+*Maximum value* : `10`|integer(int32)
 |*sampleNumberNoDescription* +
-_optional_|*Minimum value* : `0.0` +
-*Maximum value* : `10.0`|integer(int32)
+_optional_|*Minimum value* : `0` +
+*Maximum value* : `10`|integer(int32)
 |*sampleNumberOnlyMaximum* +
 _optional_|sample int with range to 10 +
-*Maximum value* : `10.0`|integer(int32)
+*Maximum value* : `10`|integer(int32)
 |*sampleNumberOnlyMinimum* +
 _optional_|sample int with range from 0 +
-*Minimum value* : `0.0`|integer(int32)
+*Minimum value* : `0`|integer(int32)
 |*sampleStringComplete* +
 _optional_|Sample string with range 0-2 and a pattern +
 *Length* : `0 - 2` +

--- a/src/test/resources/expected/markdown/default/definitions.md
+++ b/src/test/resources/expected/markdown/default/definitions.md
@@ -19,7 +19,7 @@
 |**complete**  <br>*optional*||boolean|
 |**id**  <br>*optional*||integer(int64)|
 |**petId**  <br>*optional*||integer(int64)|
-|**quantity**  <br>*optional*|**Default** : `0`  <br>**Minimum value** : `0.0`  <br>**Maximum value** : `10000.0`  <br>**Example** : `10`|integer(int32)|
+|**quantity**  <br>*optional*|**Default** : `0`  <br>**Minimum value** : `0`  <br>**Maximum value** : `10000`  <br>**Example** : `10`|integer(int32)|
 |**shipDate**  <br>*optional*||string(date-time)|
 |**status**  <br>*optional*|Order Status|enum (Ordered, Cancelled)|
 

--- a/src/test/resources/expected/markdown/idxref/definitions.md
+++ b/src/test/resources/expected/markdown/idxref/definitions.md
@@ -19,7 +19,7 @@
 |**complete**  <br>*optional*||boolean|
 |**id**  <br>*optional*||integer(int64)|
 |**petId**  <br>*optional*||integer(int64)|
-|**quantity**  <br>*optional*|**Default** : `0`  <br>**Minimum value** : `0.0`  <br>**Maximum value** : `10000.0`  <br>**Example** : `10`|integer(int32)|
+|**quantity**  <br>*optional*|**Default** : `0`  <br>**Minimum value** : `0`  <br>**Maximum value** : `10000`  <br>**Example** : `10`|integer(int32)|
 |**shipDate**  <br>*optional*||string(date-time)|
 |**status**  <br>*optional*|Order Status|enum (Ordered, Cancelled)|
 

--- a/src/test/resources/json/swagger_validators.json
+++ b/src/test/resources/json/swagger_validators.json
@@ -58,6 +58,31 @@
 					"format":"int32",
 					"description": "sample int with range to 10",
 					"maximum": 10
+				},
+				"sampleDoubleComplete": {
+					"type":"number",
+					"format":"double",
+					"description": "sample double with range 0.0-10.0",
+					"minimum": 0.0,
+					"maximum": 10.0
+				},
+				"sampleDoubleNoDescription": {
+					"type":"number",
+					"format":"double",
+					"minimum": 0.0,
+					"maximum": 10.0
+				},
+				"sampleDoubleOnlyMinimum": {
+					"type":"number",
+					"format":"double",
+					"description": "sample double with range from 0.0",
+					"minimum": 0.0
+				},
+				"sampleDoubleOnlyMaximum": {
+					"type":"number",
+					"format":"double",
+					"description": "sample double with range to 10.0",
+					"maximum": 10.0
 				}
 			}
 		}


### PR DESCRIPTION
Hi, swagger2markup currently _always_ formats min/max value as a decimal, which looks weird when the property is an integer. This PR formats the min/max for integers as integers and decimal for decimals.