### PR TITLE
Added support for exclusiveMin and exclusiveMax

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/document/builder/MarkupDocumentBuilder.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/builder/MarkupDocumentBuilder.java
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 import static io.github.swagger2markup.internal.utils.MapUtils.toKeySet;
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -58,8 +59,10 @@ public abstract class MarkupDocumentBuilder {
     
     protected final String PATTERN_COLUMN;
     protected final String MINVALUE_COLUMN;
+    protected final String MINVALUE_EXCLUSIVE_COLUMN;
     protected final String MAXVALUE_COLUMN;
-    
+    protected final String MAXVALUE_EXCLUSIVE_COLUMN;
+
     
     protected final String EXAMPLE_COLUMN;
     protected final String SCHEMA_COLUMN;
@@ -103,7 +106,9 @@ public abstract class MarkupDocumentBuilder {
         PATTERN_COLUMN = labels.getString("pattern_column");
         MINVALUE_COLUMN = labels.getString("minvalue_column");
         MAXVALUE_COLUMN = labels.getString("maxvalue_column");
-        
+        MINVALUE_EXCLUSIVE_COLUMN = labels.getString("minvalue_exclusive_column");
+        MAXVALUE_EXCLUSIVE_COLUMN = labels.getString("maxvalue_exclusive_column");
+
         EXAMPLE_COLUMN = labels.getString("example_column");
         FLAGS_COLUMN = labels.getString("flags.column");
         FLAGS_REQUIRED = labels.getString("flags.required");
@@ -211,15 +216,17 @@ public abstract class MarkupDocumentBuilder {
                 Integer minlength = PropertyUtils.getMinlength(property);
                 String pattern = PropertyUtils.getPattern(property);
                 Number minValue = PropertyUtils.getMin(property);
+                Boolean exclusiveMin = PropertyUtils.getExclusiveMin(property);
                 Number maxValue = PropertyUtils.getMax(property);
+                Boolean exclusiveMax = PropertyUtils.getExclusiveMax(property);
 
                 MarkupDocBuilder propertyNameContent = copyMarkupDocBuilder();
                 propertyNameContent.boldTextLine(propertyName, true);
-                if (BooleanUtils.isTrue(property.getRequired()))
+                if (isTrue(property.getRequired()))
                     propertyNameContent.italicText(FLAGS_REQUIRED.toLowerCase());
                 else
                     propertyNameContent.italicText(FLAGS_OPTIONAL.toLowerCase());
-                if (BooleanUtils.isTrue(property.getReadOnly())) {
+                if (isTrue(property.getReadOnly())) {
                     propertyNameContent.newLine(true);
                     propertyNameContent.italicText(FLAGS_READ_ONLY.toLowerCase());
                 }
@@ -270,17 +277,21 @@ public abstract class MarkupDocumentBuilder {
                 	
                     descriptionContent.boldText(PATTERN_COLUMN).text(COLON).literalText(Json.pretty(pattern));
                 }
-                
+
                 if(minValue != null){
                 	if (isNotBlank(descriptionContent.toString()))
                         descriptionContent.newLine(true);
-                    descriptionContent.boldText(MINVALUE_COLUMN).text(COLON).literalText(minValue.toString());
+
+                    String minValueColumn = isTrue(exclusiveMin) ? MINVALUE_EXCLUSIVE_COLUMN : MINVALUE_COLUMN;
+                    descriptionContent.boldText(minValueColumn).text(COLON).literalText(minValue.toString());
                 }
                 
                 if(maxValue != null){
                 	if (isNotBlank(descriptionContent.toString()))
                         descriptionContent.newLine(true);
-                    descriptionContent.boldText(MAXVALUE_COLUMN).text(COLON).literalText(maxValue.toString());
+
+                    String maxValueColumn = isTrue(exclusiveMax) ? MAXVALUE_EXCLUSIVE_COLUMN : MAXVALUE_COLUMN;
+                    descriptionContent.boldText(maxValueColumn).text(COLON).literalText(maxValue.toString());
                 }
                 
                 if (example != null) {

--- a/src/main/java/io/github/swagger2markup/internal/utils/PropertyUtils.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/PropertyUtils.java
@@ -198,6 +198,23 @@ public final class PropertyUtils {
         }
         return min;
     }
+
+    /**
+     * Retrieves the exclusiveMinimum value of a property, or otherwise returns null.
+     *
+     * @param property the property
+     * @return the exclusiveMinimum value of the property, or otherwise null
+     */
+    public static Boolean getExclusiveMin(Property property) {
+        Validate.notNull(property, "property must not be null");
+        Boolean exclusiveMin = null;
+
+        if (property instanceof AbstractNumericProperty){
+            AbstractNumericProperty numericProperty = (AbstractNumericProperty) property;
+            exclusiveMin = numericProperty.getExclusiveMinimum();
+        }
+        return exclusiveMin;
+    }
     
     /**
      * Retrieves the minimum value of a property, or otherwise returns null.
@@ -217,6 +234,23 @@ public final class PropertyUtils {
             max = numericProperty.getMaximum();
         }
         return max;
+    }
+
+    /**
+     * Retrieves the exclusiveMaximum value of a property, or otherwise returns null.
+     *
+     * @param property the property
+     * @return the exclusiveMaximum value of the property, or otherwise null
+     */
+    public static Boolean getExclusiveMax(Property property) {
+        Validate.notNull(property, "property must not be null");
+        Boolean exclusiveMax = null;
+
+        if (property instanceof AbstractNumericProperty){
+            AbstractNumericProperty numericProperty = (AbstractNumericProperty) property;
+            exclusiveMax = numericProperty.getExclusiveMaximum();
+        }
+        return exclusiveMax;
     }
     
     /**

--- a/src/main/resources/io/github/swagger2markup/lang/labels_de.properties
+++ b/src/main/resources/io/github/swagger2markup/lang/labels_de.properties
@@ -1,4 +1,5 @@
 definitions=Definitionen
+
 default_column=Standard
 
 # validators
@@ -7,7 +8,9 @@ maxlength_column=Maximale Länge
 length_column=Länge
 pattern_column=Pattern
 minvalue_column=Mindestwert
+minvalue_exclusive_column=Mindestwert (exklusiv)
 maxvalue_column=Maximalwert
+maxvalue_exclusive_column=Maximalwert (exklusiv)
 
 example_column=Beispiel
 flags.column=Flags
@@ -37,7 +40,7 @@ uri_scheme=URI Schema
 host=Host
 base_path=Basis-Pfad
 schemes=Schemata
-security_name=
+security_name=Name
 security_type=Typ
 security_in=In
 security_flow=Flow

--- a/src/main/resources/io/github/swagger2markup/lang/labels_en.properties
+++ b/src/main/resources/io/github/swagger2markup/lang/labels_en.properties
@@ -8,7 +8,9 @@ maxlength_column=Maximal length
 length_column=Length
 pattern_column=Pattern
 minvalue_column=Minimum value
+minvalue_exclusive_column=Minimum value (exclusive)
 maxvalue_column=Maximum value
+maxvalue_exclusive_column=Maximum value (exclusive)
 
 example_column=Example
 flags.column=Flags

--- a/src/main/resources/io/github/swagger2markup/lang/labels_es.properties
+++ b/src/main/resources/io/github/swagger2markup/lang/labels_es.properties
@@ -8,7 +8,9 @@ maxlength_column=Longitud máxima
 length_column=Longitud
 pattern_column=Patrón
 minvalue_column=Valor mínimo
+minvalue_exclusive_column=Valor mínimo (exclusivo)
 maxvalue_column=Valor máximo
+maxvalue_exclusive_column=Valor máximo (exclusivo)
 
 example_column=Ejemplo
 flags.column=Flags

--- a/src/main/resources/io/github/swagger2markup/lang/labels_fr.properties
+++ b/src/main/resources/io/github/swagger2markup/lang/labels_fr.properties
@@ -8,7 +8,9 @@ maxlength_column=Longueur maximale
 length_column=Longueur
 pattern_column=Mod\u00E8le
 minvalue_column=Valeur minimale
+minvalue_exclusive_column=Valeur minimale (exclusif)
 maxvalue_column=Valeur maximale
+maxvalue_exclusive_column=Valeur maximale (exclusif)
 
 example_column=Exemple
 flags.column=Modificateurs

--- a/src/main/resources/io/github/swagger2markup/lang/labels_ru.properties
+++ b/src/main/resources/io/github/swagger2markup/lang/labels_ru.properties
@@ -8,7 +8,9 @@ maxlength_column=Maximal length
 length_column=Length
 pattern_column=Pattern
 minvalue_column=Minimum value
+minvalue_exclusive_column=Minimum value (exclusive)
 maxvalue_column=Maximum value
+maxvalue_exclusive_column=Maximum value (exclusive)
 
 flags.column=Flags
 flags.required=\u041E\u0431\u044F\u0437\u0430\u0442\u0435\u043B\u044C\u043D\u043E

--- a/src/main/resources/io/github/swagger2markup/lang/labels_tr.properties
+++ b/src/main/resources/io/github/swagger2markup/lang/labels_tr.properties
@@ -8,7 +8,9 @@ maxlength_column=Maximal length
 length_column=Length
 pattern_column=Pattern
 minvalue_column=Minimum value
+minvalue_exclusive_column=Minimum value (exclusive)
 maxvalue_column=Maximum value
+maxvalue_exclusive_column=Maximum value (exclusive)
 
 example_column=\u00D6rnek
 flags.column=Bayraklar

--- a/src/main/resources/io/github/swagger2markup/lang/labels_zh.properties
+++ b/src/main/resources/io/github/swagger2markup/lang/labels_zh.properties
@@ -8,7 +8,9 @@ maxlength_column=最大长度
 length_column=长度
 pattern_column=模式
 minvalue_column=最小值
+minvalue_exclusive_column=最小值(不包括)
 maxvalue_column=最大值
+maxvalue_exclusive_column=最大值(不包括)
 
 example_column=例子
 flags.column=标志

--- a/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
+++ b/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
@@ -389,48 +389,25 @@ public class AsciidocConverterTest {
 
     @Test
     public void testSwagger2AsciiDocConversionWithRussianOutputLanguage() throws IOException, URISyntaxException {
-        //Given
-        Path file = Paths.get(AsciidocConverterTest.class.getResource("/yaml/swagger_petstore.yaml").toURI());
-        Path outputDirectory = Paths.get("build/test/asciidoc/generated");
-        FileUtils.deleteQuietly(outputDirectory.toFile());
-
-        //When
-        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder()
-                .withOutputLanguage(Language.RU)
-                .build();
-        Swagger2MarkupConverter.from(file)
-                .withConfig(config)
-                .build()
-                .toFolder(outputDirectory);
-
-        //Then
-        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("definitions.adoc")), Charset.forName("UTF-8")))
-                .contains("== Определения");
+        testSwagger2AsciiDocConversionWithOutputLanguage(Language.RU, "definitions.adoc", "== Определения");
     }
 
     @Test
     public void testSwagger2AsciiDocConversionWithFrenchOutputLanguage() throws IOException, URISyntaxException {
-        //Given
-        Path file = Paths.get(AsciidocConverterTest.class.getResource("/yaml/swagger_petstore.yaml").toURI());
-        Path outputDirectory = Paths.get("build/test/asciidoc/generated");
-        FileUtils.deleteQuietly(outputDirectory.toFile());
+        testSwagger2AsciiDocConversionWithOutputLanguage(Language.FR, "overview.adoc", "== Sch\u00E9ma d'URI");
+    }
 
-        //When
-        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder()
-                .withOutputLanguage(Language.FR)
-                .build();
-        Swagger2MarkupConverter.from(file)
-                .withConfig(config)
-                .build()
-                .toFolder(outputDirectory);
-
-        //Then
-        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("overview.adoc")), Charset.forName("UTF-8")))
-                .contains("== Sch\u00E9ma d'URI");
+    @Test
+    public void testSwagger2AsciiDocConversionWithGermanOutputLanguage() throws IOException, URISyntaxException {
+        testSwagger2AsciiDocConversionWithOutputLanguage(Language.DE, "definitions.adoc", "Beschreibung");
     }
 
     @Test
     public void testSwagger2AsciiDocConversionWithSpanishOutputLanguage() throws IOException, URISyntaxException {
+        testSwagger2AsciiDocConversionWithOutputLanguage(Language.ES, "definitions.adoc", "Descripción");
+    }
+
+    private void testSwagger2AsciiDocConversionWithOutputLanguage(Language language, String outputFilename, String expected) throws IOException, URISyntaxException {
         //Given
         Path file = Paths.get(AsciidocConverterTest.class.getResource("/yaml/swagger_petstore.yaml").toURI());
         Path outputDirectory = Paths.get("build/test/asciidoc/generated");
@@ -438,7 +415,7 @@ public class AsciidocConverterTest {
 
         //When
         Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder()
-                .withOutputLanguage(Language.ES)
+                .withOutputLanguage(language)
                 .build();
         Swagger2MarkupConverter.from(file)
                 .withConfig(config)
@@ -446,8 +423,8 @@ public class AsciidocConverterTest {
                 .toFolder(outputDirectory);
 
         //Then
-        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("definitions.adoc")), Charset.forName("UTF-8")))
-                .contains("Descripción");
+        assertThat(new String(Files.readAllBytes(outputDirectory.resolve(outputFilename)), Charset.forName("UTF-8")))
+                .contains(expected);
     }
 
     @Test

--- a/src/test/resources/expected/asciidoc/validators/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/validators/definitions.adoc
@@ -12,6 +12,16 @@
 _optional_|sample double with range 0.0-10.0 +
 *Minimum value* : `0.0` +
 *Maximum value* : `10.0`|number(double)
+|*sampleDoubleExclusiveBoth* +
+_optional_|sample double with range 0.0-10.0 (both exclusive) +
+*Minimum value (exclusive)* : `0.0` +
+*Maximum value (exclusive)* : `10.0`|number(double)
+|*sampleDoubleExclusiveMaximum* +
+_optional_|sample double with range to 10.0 (exclusive) +
+*Maximum value (exclusive)* : `10.0`|number(double)
+|*sampleDoubleExclusiveMinimum* +
+_optional_|sample double with range from 0.0 (exclusive) +
+*Minimum value (exclusive)* : `0.0`|number(double)
 |*sampleDoubleNoDescription* +
 _optional_|*Minimum value* : `0.0` +
 *Maximum value* : `10.0`|number(double)

--- a/src/test/resources/json/swagger_validators.json
+++ b/src/test/resources/json/swagger_validators.json
@@ -83,6 +83,29 @@
 					"format":"double",
 					"description": "sample double with range to 10.0",
 					"maximum": 10.0
+				},
+				"sampleDoubleExclusiveMinimum": {
+					"type":"number",
+					"format":"double",
+					"description": "sample double with range from 0.0 (exclusive)",
+					"minimum": 0.0,
+					"exclusiveMinimum": true
+				},
+				"sampleDoubleExclusiveMaximum": {
+					"type":"number",
+					"format":"double",
+					"description": "sample double with range to 10.0 (exclusive)",
+					"maximum": 10.0,
+					"exclusiveMaximum": true
+				},
+				"sampleDoubleExclusiveBoth": {
+					"type":"number",
+					"format":"double",
+					"description": "sample double with range 0.0-10.0 (both exclusive)",
+					"minimum": 0.0,
+					"maximum": 10.0,
+					"exclusiveMinimum": true,
+					"exclusiveMaximum": true
 				}
 			}
 		}


### PR DESCRIPTION
As a follow up to #192, this PR adds support for exclusiveMin and exclusiveMax by changing the min/max label, i.e.

`exclusiveMinimum == false`: **Minimum value**
`exclusiveMinimum == true`: **Minimum value (exclusive)**
`exclusiveMaximum == false`: **Maximum value**
`exclusiveMaximum == true`: **Maximum value (exclusive)**

Inclusive is assumed to be the default, so there's no `(inclusive)` required.
