### PR TITLE
Fix NPE for response headers with relative definitions

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/component/ResponseComponent.java
+++ b/src/main/java/io/github/swagger2markup/internal/component/ResponseComponent.java
@@ -103,7 +103,7 @@ public class ResponseComponent extends MarkupComponent<ResponseComponent.Paramet
                         descriptionBuilder.newLine(true);
                         Property headerProperty = header.getValue();
                         PropertyAdapter headerPropertyAdapter = new PropertyAdapter(headerProperty);
-                        Type propertyType = headerPropertyAdapter.getType(null);
+                        Type propertyType = headerPropertyAdapter.getType(definitionDocumentResolver);
                         String headerDescription = markupDescription(config.getSwaggerMarkupLanguage(), markupDocBuilder, headerProperty.getDescription());
                         Optional<Object> optionalDefaultValue = headerPropertyAdapter.getDefaultValue();
 


### PR DESCRIPTION
Fix NPE for response headers with relative definitions
as reported https://github.com/Swagger2Markup/swagger2markup-maven-plugin/issues/31
