### PR TITLE
Multi-Valued Dynamic Content Folders

### DIFF
--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
@@ -215,6 +215,12 @@ public interface Swagger2MarkupConfig {
     LineSeparator getLineSeparator();
 
     /**
+     * Specifies the array element separator to use for multi-valued properties.
+     * @return the folder separator if any.
+     */
+    Character getDocumentFolderSeparator();
+
+    /**
      * Returns properties for extensions.
      *
      * @return the extension properties

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
@@ -215,10 +215,17 @@ public interface Swagger2MarkupConfig {
     LineSeparator getLineSeparator();
 
     /**
-     * Specifies the array element separator to use for multi-valued properties.
-     * @return the folder separator if any.
+     * Specifies the array element delimiter to use for multi-valued properties.
+     * @return the element delimiter if any
      */
-    Character getDocumentFolderSeparator();
+    Character getListDelimiter();
+    
+    /**
+     * Optionally allow lists in property values. Uses the {{@link #getListDelimiter()} to 
+     * delimit list values.
+     * @return whether lists are converted to arrays
+     */
+    boolean isListDelimiterEnabled();
 
     /**
      * Returns properties for extensions.

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
@@ -17,10 +17,12 @@ package io.github.swagger2markup;
 
 import io.github.swagger2markup.markup.builder.MarkupLanguage;
 import io.github.swagger2markup.utils.URIUtils;
+
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ConfigurationConverter;
 import org.apache.commons.configuration2.MapConfiguration;
+import org.apache.commons.configuration2.ex.ConversionException;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -50,6 +52,7 @@ public class Swagger2MarkupProperties {
     public static final String FLAT_BODY_ENABLED = PROPERTIES_PREFIX + ".flatBodyEnabled";
     public static final String PATH_SECURITY_SECTION_ENABLED = PROPERTIES_PREFIX + ".pathSecuritySectionEnabled";
     public static final String ANCHOR_PREFIX = PROPERTIES_PREFIX + ".anchorPrefix";
+    public static final String DOCUMENT_FOLDER_SEPARATOR = PROPERTIES_PREFIX + ".documentFolderSeparator";
     public static final String OVERVIEW_DOCUMENT = PROPERTIES_PREFIX + ".overviewDocument";
     public static final String PATHS_DOCUMENT = PROPERTIES_PREFIX + ".pathsDocument";
     public static final String DEFINITIONS_DOCUMENT = PROPERTIES_PREFIX + ".definitionsDocument";
@@ -216,6 +219,34 @@ public class Swagger2MarkupProperties {
         } else {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Return a list of Path property values associated with the given key, 
+     * or {@code defaultValue} if the key cannot be resolved.
+     * 
+     * @param key the property name to resolve
+     * @return The list of Path properties
+     * @throws IllegalStateException if the value cannot be mapped to an array of strings
+     */
+    public Optional<List<Path>> getPathList(String key) {
+        List<Path> pathList = new ArrayList<Path>();
+
+        try {
+            String[] stringList = configuration.getStringArray(key);
+
+            for (String pathStr : stringList) {
+                pathList.add(Paths.get(pathStr));
+            }
+
+            if (pathList.size() > 0) {
+                return Optional.of(pathList);
+            }
+        } catch (ConversionException ce) {
+            throw new IllegalStateException(String.format("requested key [%s] is not convertable to an array", key));
+        }
+
+        return Optional.ofNullable((List<Path>)null);
     }
 
     /**

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
@@ -52,7 +52,8 @@ public class Swagger2MarkupProperties {
     public static final String FLAT_BODY_ENABLED = PROPERTIES_PREFIX + ".flatBodyEnabled";
     public static final String PATH_SECURITY_SECTION_ENABLED = PROPERTIES_PREFIX + ".pathSecuritySectionEnabled";
     public static final String ANCHOR_PREFIX = PROPERTIES_PREFIX + ".anchorPrefix";
-    public static final String DOCUMENT_FOLDER_SEPARATOR = PROPERTIES_PREFIX + ".documentFolderSeparator";
+    public static final String LIST_DELIMITER = PROPERTIES_PREFIX + ".listDelimiter";
+    public static final String LIST_DELIMITER_ENABLED = PROPERTIES_PREFIX + ".listDelimiterEnabled";
     public static final String OVERVIEW_DOCUMENT = PROPERTIES_PREFIX + ".overviewDocument";
     public static final String PATHS_DOCUMENT = PROPERTIES_PREFIX + ".pathsDocument";
     public static final String DEFINITIONS_DOCUMENT = PROPERTIES_PREFIX + ".definitionsDocument";
@@ -229,7 +230,7 @@ public class Swagger2MarkupProperties {
      * @return The list of Path properties
      * @throws IllegalStateException if the value cannot be mapped to an array of strings
      */
-    public Optional<List<Path>> getPathList(String key) {
+    public List<Path> getPathList(String key) {
         List<Path> pathList = new ArrayList<Path>();
 
         try {
@@ -238,15 +239,11 @@ public class Swagger2MarkupProperties {
             for (String pathStr : stringList) {
                 pathList.add(Paths.get(pathStr));
             }
-
-            if (pathList.size() > 0) {
-                return Optional.of(pathList);
-            }
         } catch (ConversionException ce) {
             throw new IllegalStateException(String.format("requested key [%s] is not convertable to an array", key));
         }
 
-        return Optional.ofNullable((List<Path>)null);
+        return pathList;
     }
 
     /**

--- a/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
+++ b/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
@@ -111,11 +111,16 @@ public class Swagger2MarkupConfigBuilder {
         Optional<Pattern> headerPattern = swagger2MarkupProperties.getHeaderPattern(HEADER_REGEX);
 
         config.headerPattern = headerPattern.orElse(null);
-
-        Optional<String> documentFolderSeparator = swagger2MarkupProperties.getString(DOCUMENT_FOLDER_SEPARATOR);
-        if (documentFolderSeparator.isPresent() && StringUtils.isNoneBlank(documentFolderSeparator.get()) && documentFolderSeparator.get().length() == 1) {
-            config.documentFolderSeparator = Character.valueOf(documentFolderSeparator.get().charAt(0));
-            ((AbstractConfiguration)configuration).setListDelimiterHandler(new DefaultListDelimiterHandler(config.documentFolderSeparator));
+        
+        config.listDelimiterEnabled = swagger2MarkupProperties.getBoolean(LIST_DELIMITER_ENABLED, false);
+        
+        Optional<String> listDelimiter = swagger2MarkupProperties.getString(LIST_DELIMITER);
+        if (listDelimiter.isPresent() && StringUtils.isNoneBlank(listDelimiter.get()) && listDelimiter.get().length() == 1) {
+            config.listDelimiter = Character.valueOf(listDelimiter.get().charAt(0));
+        }
+        
+        if (config.listDelimiterEnabled && config.listDelimiter != null && configuration instanceof AbstractConfiguration) {
+            ((AbstractConfiguration)configuration).setListDelimiterHandler(new DefaultListDelimiterHandler(config.listDelimiter));
         }
 
         Configuration swagger2markupConfiguration = compositeConfiguration.subset(PROPERTIES_PREFIX);
@@ -215,6 +220,28 @@ public class Swagger2MarkupConfigBuilder {
      */
     public Swagger2MarkupConfigBuilder withSeparatedOperations() {
         config.separatedOperationsEnabled = true;
+        return this;
+    }
+    
+    /**
+     * Allows properties to contain a list of elements delimited by a specified character.
+     * @return this builder
+     */
+    public Swagger2MarkupConfigBuilder withListDelimiter() {
+        config.listDelimiterEnabled = true;
+        return this;
+    }
+    
+    /**
+     * Specifies the list delimiter which should be used.
+     * 
+     * @param delimiter the delimiter
+     * @return this builder
+     */
+    public Swagger2MarkupConfigBuilder withListDelimiter(Character delimiter) {
+        Validate.notNull(delimiter, "%s must not be null", "delimiter");
+        config.listDelimiter = delimiter;
+        config.listDelimiterEnabled = true;
         return this;
     }
 
@@ -562,7 +589,8 @@ public class Swagger2MarkupConfigBuilder {
         private String securityDocument;
         private String separatedOperationsFolder;
         private String separatedDefinitionsFolder;
-        private Character documentFolderSeparator;
+        private Character listDelimiter;
+        private boolean listDelimiterEnabled;
 
         private List<PageBreakLocations> pageBreakLocations;
 
@@ -736,8 +764,13 @@ public class Swagger2MarkupConfigBuilder {
         }
 
         @Override
-        public Character getDocumentFolderSeparator() {
-            return documentFolderSeparator;
+        public Character getListDelimiter() {
+            return listDelimiter;
+        }
+        
+        @Override
+        public boolean isListDelimiterEnabled() {
+            return listDelimiterEnabled;
         }
 
         @Override

--- a/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
+++ b/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
@@ -17,15 +17,17 @@
 package io.github.swagger2markup.builder;
 
 import com.google.common.collect.Ordering;
+
 import io.github.swagger2markup.*;
-import io.github.swagger2markup.Swagger2MarkupProperties;
 import io.github.swagger2markup.markup.builder.LineSeparator;
 import io.github.swagger2markup.markup.builder.MarkupLanguage;
 import io.github.swagger2markup.model.PathOperation;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.parameters.Parameter;
+
 import org.apache.commons.configuration2.*;
 import org.apache.commons.configuration2.builder.fluent.Configurations;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -109,6 +111,12 @@ public class Swagger2MarkupConfigBuilder {
         Optional<Pattern> headerPattern = swagger2MarkupProperties.getHeaderPattern(HEADER_REGEX);
 
         config.headerPattern = headerPattern.orElse(null);
+
+        Optional<String> documentFolderSeparator = swagger2MarkupProperties.getString(DOCUMENT_FOLDER_SEPARATOR);
+        if (documentFolderSeparator.isPresent() && StringUtils.isNoneBlank(documentFolderSeparator.get()) && documentFolderSeparator.get().length() == 1) {
+            config.documentFolderSeparator = Character.valueOf(documentFolderSeparator.get().charAt(0));
+            ((AbstractConfiguration)configuration).setListDelimiterHandler(new DefaultListDelimiterHandler(config.documentFolderSeparator));
+        }
 
         Configuration swagger2markupConfiguration = compositeConfiguration.subset(PROPERTIES_PREFIX);
         Configuration extensionsConfiguration = swagger2markupConfiguration.subset(EXTENSION_PREFIX);
@@ -554,6 +562,7 @@ public class Swagger2MarkupConfigBuilder {
         private String securityDocument;
         private String separatedOperationsFolder;
         private String separatedDefinitionsFolder;
+        private Character documentFolderSeparator;
 
         private List<PageBreakLocations> pageBreakLocations;
 
@@ -724,6 +733,11 @@ public class Swagger2MarkupConfigBuilder {
         @Override
         public LineSeparator getLineSeparator() {
             return lineSeparator;
+        }
+
+        @Override
+        public Character getDocumentFolderSeparator() {
+            return documentFolderSeparator;
         }
 
         @Override

--- a/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
+++ b/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
@@ -113,10 +113,9 @@ public class Swagger2MarkupConfigBuilder {
         config.headerPattern = headerPattern.orElse(null);
         
         config.listDelimiterEnabled = swagger2MarkupProperties.getBoolean(LIST_DELIMITER_ENABLED, false);
-        
-        Optional<String> listDelimiter = swagger2MarkupProperties.getString(LIST_DELIMITER);
-        if (listDelimiter.isPresent() && StringUtils.isNoneBlank(listDelimiter.get()) && listDelimiter.get().length() == 1) {
-            config.listDelimiter = Character.valueOf(listDelimiter.get().charAt(0));
+        OptionalInt delimiter = swagger2MarkupProperties.getString(LIST_DELIMITER, "").chars().findFirst();
+        if (delimiter.isPresent()) {
+            config.listDelimiter = Character.valueOf((char)delimiter.getAsInt());
         }
         
         if (config.listDelimiterEnabled && config.listDelimiter != null && configuration instanceof AbstractConfiguration) {

--- a/src/main/resources/io/github/swagger2markup/config/default.properties
+++ b/src/main/resources/io/github/swagger2markup/config/default.properties
@@ -24,3 +24,5 @@ swagger2markup.definitionOrderBy=NATURAL
 swagger2markup.parameterOrderBy=NATURAL
 swagger2markup.propertyOrderBy=NATURAL
 swagger2markup.responseOrderBy=NATURAL
+swagger2markup.listDelimiterEnabled=false
+swagger2markup.listDelimiter=,

--- a/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
+++ b/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
@@ -79,7 +79,7 @@ public class Swagger2MarkupConfigBuilderTest {
                 "uniqueId2.customPropertyList1"
                 );
         assertThat(config.getExtensionsProperties().getString("uniqueId1.customProperty1").get()).isEqualTo("123");
-        assertThat(config.getExtensionsProperties().getPathList("uniqueId2.customPropertyList1").get()).hasSize(1)
+        assertThat(config.getExtensionsProperties().getPathList("uniqueId2.customPropertyList1")).hasSize(1)
         .containsOnly(Paths.get("123,456"));
     }
 
@@ -115,7 +115,8 @@ public class Swagger2MarkupConfigBuilderTest {
         assertThat(config.getSecurityDocument()).isEqualTo("securityTest");
         assertThat(config.getSeparatedDefinitionsFolder()).isEqualTo("definitionsTest");
         assertThat(config.getSeparatedOperationsFolder()).isEqualTo("operationsTest");
-        assertThat(config.getDocumentFolderSeparator()).isEqualTo(Character.valueOf(','));
+        assertThat(config.isListDelimiterEnabled()).isEqualTo(true);
+        assertThat(config.getListDelimiter()).isEqualTo(Character.valueOf('|'));
         assertThat(config.getTagOrderBy()).isEqualTo(OrderBy.AS_IS);
         assertThat(config.getTagOrdering()).isNull();
         assertThat(config.isFlatBodyEnabled()).isTrue();
@@ -130,7 +131,7 @@ public class Swagger2MarkupConfigBuilderTest {
                 "uniqueId2.customProperty2",
                 "uniqueId2.customPropertyList1"
                 );
-        assertThat(config.getExtensionsProperties().getPathList("uniqueId2.customPropertyList1").get()).hasSize(2)
+        assertThat(config.getExtensionsProperties().getPathList("uniqueId2.customPropertyList1")).hasSize(2)
         .containsOnly(Paths.get("123"), Paths.get("456"));
     }
 
@@ -191,6 +192,21 @@ public class Swagger2MarkupConfigBuilderTest {
         builder.withResponseOrdering(Ordering.<String>natural());
         assertThat(builder.config.getResponseOrderBy()).isEqualTo(OrderBy.CUSTOM);
         assertThat(builder.config.getResponseOrdering()).isEqualTo(Ordering.natural());
+        
+        assertThat(builder.config.isListDelimiterEnabled()).isEqualTo(false);
+        builder.withListDelimiter();
+        assertThat(builder.config.getListDelimiter()).isEqualTo(Character.valueOf(','));
+        assertThat(builder.config.isListDelimiterEnabled()).isEqualTo(true);
+        
     }
+    
+    @Test
+    public void testConfigBuilderListDelimiter() {
+        Swagger2MarkupConfigBuilder builder = new Swagger2MarkupConfigBuilder();
 
+        assertThat(builder.config.isListDelimiterEnabled()).isEqualTo(false);
+        builder.withListDelimiter(Character.valueOf('|'));
+        assertThat(builder.config.getListDelimiter()).isEqualTo(Character.valueOf('|'));
+        assertThat(builder.config.isListDelimiterEnabled()).isEqualTo(true);
+    }
 }

--- a/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
+++ b/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
@@ -21,6 +21,7 @@ import io.github.swagger2markup.markup.builder.MarkupLanguage;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -35,6 +36,7 @@ public class Swagger2MarkupConfigBuilderTest {
         configMap.put(Swagger2MarkupProperties.MARKUP_LANGUAGE, MarkupLanguage.MARKDOWN.toString());
         configMap.put("swagger2markup.extensions.uniqueId1.customProperty1", "123");
         configMap.put("swagger2markup.extensions.uniqueId1.customProperty2", "123");
+        configMap.put("swagger2markup.extensions.uniqueId2.customPropertyList1", "123,456");
         configMap.put("swagger2markup.uniqueId1.customProperty1", "123");
         configMap.put("swagger2markup.uniqueId1.customProperty2", "123");
 
@@ -71,10 +73,14 @@ public class Swagger2MarkupConfigBuilderTest {
         assertThat(config.isInterDocumentCrossReferencesEnabled()).isFalse();
         assertThat(config.isSeparatedDefinitionsEnabled()).isFalse();
         assertThat(config.isSeparatedOperationsEnabled()).isFalse();
-        assertThat(config.getExtensionsProperties().getKeys()).hasSize(2)
-                .containsOnly("uniqueId1.customProperty1",
-                        "uniqueId1.customProperty2"
+        assertThat(config.getExtensionsProperties().getKeys()).hasSize(3)
+        .containsOnly("uniqueId1.customProperty1",
+                "uniqueId1.customProperty2",
+                "uniqueId2.customPropertyList1"
                 );
+        assertThat(config.getExtensionsProperties().getString("uniqueId1.customProperty1").get()).isEqualTo("123");
+        assertThat(config.getExtensionsProperties().getPathList("uniqueId2.customPropertyList1").get()).hasSize(1)
+        .containsOnly(Paths.get("123,456"));
     }
 
 
@@ -109,6 +115,7 @@ public class Swagger2MarkupConfigBuilderTest {
         assertThat(config.getSecurityDocument()).isEqualTo("securityTest");
         assertThat(config.getSeparatedDefinitionsFolder()).isEqualTo("definitionsTest");
         assertThat(config.getSeparatedOperationsFolder()).isEqualTo("operationsTest");
+        assertThat(config.getDocumentFolderSeparator()).isEqualTo(Character.valueOf(','));
         assertThat(config.getTagOrderBy()).isEqualTo(OrderBy.AS_IS);
         assertThat(config.getTagOrdering()).isNull();
         assertThat(config.isFlatBodyEnabled()).isTrue();
@@ -116,12 +123,15 @@ public class Swagger2MarkupConfigBuilderTest {
         assertThat(config.isInterDocumentCrossReferencesEnabled()).isTrue();
         assertThat(config.isSeparatedDefinitionsEnabled()).isTrue();
         assertThat(config.isSeparatedOperationsEnabled()).isTrue();
-        assertThat(config.getExtensionsProperties().getKeys()).hasSize(4)
-                .containsOnly("uniqueId1.customProperty1",
-                        "uniqueId1.customProperty2",
-                        "uniqueId2.customProperty1",
-                        "uniqueId2.customProperty2"
+        assertThat(config.getExtensionsProperties().getKeys()).hasSize(5)
+        .containsOnly("uniqueId1.customProperty1",
+                "uniqueId1.customProperty2",
+                "uniqueId2.customProperty1",
+                "uniqueId2.customProperty2",
+                "uniqueId2.customPropertyList1"
                 );
+        assertThat(config.getExtensionsProperties().getPathList("uniqueId2.customPropertyList1").get()).hasSize(2)
+        .containsOnly(Paths.get("123"), Paths.get("456"));
     }
 
     @Test

--- a/src/test/resources/config/config.properties
+++ b/src/test/resources/config/config.properties
@@ -16,7 +16,8 @@ swagger2markup.definitionsDocument=definitionsTest
 swagger2markup.securityDocument=securityTest
 swagger2markup.separatedOperationsFolder=operationsTest
 swagger2markup.separatedDefinitionsFolder=definitionsTest
-swagger2markup.documentFolderSeparator=,
+swagger2markup.listDelimiter=|
+swagger2markup.listDelimiterEnabled=true
 swagger2markup.tagOrderBy=AS_IS
 swagger2markup.operationOrderBy=NATURAL
 swagger2markup.definitionOrderBy=AS_IS
@@ -27,5 +28,5 @@ swagger2markup.extensions.uniqueId1.customProperty1=test
 swagger2markup.extensions.uniqueId1.customProperty2=test
 swagger2markup.extensions.uniqueId2.customProperty1=test
 swagger2markup.extensions.uniqueId2.customProperty2=test
-swagger2markup.extensions.uniqueId2.customPropertyList1=123,456
+swagger2markup.extensions.uniqueId2.customPropertyList1=123|456
 

--- a/src/test/resources/config/config.properties
+++ b/src/test/resources/config/config.properties
@@ -16,6 +16,7 @@ swagger2markup.definitionsDocument=definitionsTest
 swagger2markup.securityDocument=securityTest
 swagger2markup.separatedOperationsFolder=operationsTest
 swagger2markup.separatedDefinitionsFolder=definitionsTest
+swagger2markup.documentFolderSeparator=,
 swagger2markup.tagOrderBy=AS_IS
 swagger2markup.operationOrderBy=NATURAL
 swagger2markup.definitionOrderBy=AS_IS
@@ -26,4 +27,5 @@ swagger2markup.extensions.uniqueId1.customProperty1=test
 swagger2markup.extensions.uniqueId1.customProperty2=test
 swagger2markup.extensions.uniqueId2.customProperty1=test
 swagger2markup.extensions.uniqueId2.customProperty2=test
+swagger2markup.extensions.uniqueId2.customPropertyList1=123,456
 


### PR DESCRIPTION
Adds in the capability to have array valued properties. Mostly only affects extensions that may need this. It is disabled by default and should work the same as it currently does. Array values can be enabled by setting a separator character in the "swagger2markup.documentFolderSeparator" configuration attribute.

This is a dependency so that the dynamic content extension can be altered to support multiple source folders for each content folder. Pull request for it coming next.