### PR TITLE
Fix position reference for parameters table.

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/component/ParameterTableComponent.java
+++ b/src/main/java/io/github/swagger2markup/internal/component/ParameterTableComponent.java
@@ -71,7 +71,7 @@ public class ParameterTableComponent extends MarkupComponent<ParameterTableCompo
                 .filter(this::filterParameter).collect(Collectors.toList());
 
         MarkupDocBuilder parametersBuilder = copyMarkupDocBuilder(markupDocBuilder);
-        applyPathsDocumentExtension(new PathsDocumentExtension.Context(PathsDocumentExtension.Position.OPERATION_DESCRIPTION_BEGIN, parametersBuilder, operation));
+        applyPathsDocumentExtension(new PathsDocumentExtension.Context(PathsDocumentExtension.Position.OPERATION_PARAMETERS_BEGIN, parametersBuilder, operation));
         if (CollectionUtils.isNotEmpty(filteredParameters)) {
             StringColumn.Builder typeColumnBuilder = StringColumn.builder(StringColumnId.of(labels.getLabel(TYPE_COLUMN)))
                     .putMetaData(TableComponent.WIDTH_RATIO, "2");
@@ -107,7 +107,7 @@ public class ParameterTableComponent extends MarkupComponent<ParameterTableCompo
                     schemaColumnBuilder.build(),
                     defaultColumnBuilder.build()));
         }
-        applyPathsDocumentExtension(new PathsDocumentExtension.Context(PathsDocumentExtension.Position.OPERATION_DESCRIPTION_END, parametersBuilder, operation));
+        applyPathsDocumentExtension(new PathsDocumentExtension.Context(PathsDocumentExtension.Position.OPERATION_PARAMETERS_END, parametersBuilder, operation));
         String parametersContent = parametersBuilder.toString();
 
         applyPathsDocumentExtension(new PathsDocumentExtension.Context(PathsDocumentExtension.Position.OPERATION_PARAMETERS_BEFORE, markupDocBuilder, operation));


### PR DESCRIPTION
I noticed when I tried creating a markup file for OPERATION_DESCRIPTION_BEGIN, that the content was being inserted two places: right after the path's "Description", and right after the parameter table's "Parameters" title. It looks like it is just a case of the wrong Position enum being used for the parameters table component.