### PR TITLE
Fix request path and query params' example support.

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
@@ -125,6 +125,10 @@ public class ExamplesUtil {
                     Object abstractSerializableParameterExample;
                     abstractSerializableParameterExample = ((AbstractSerializableParameter) parameter).getExample();
                     if (abstractSerializableParameterExample == null) {
+                        Map<String, Object> kvs = parameter.getVendorExtensions();
+                        abstractSerializableParameterExample = parameter.getVendorExtensions().get("x-example");
+                    }
+                    if (abstractSerializableParameterExample == null) {
                         Property item = ((AbstractSerializableParameter) parameter).getItems();
                         if (item != null) {
                             abstractSerializableParameterExample = item.getExample();

--- a/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
@@ -125,7 +125,6 @@ public class ExamplesUtil {
                     Object abstractSerializableParameterExample;
                     abstractSerializableParameterExample = ((AbstractSerializableParameter) parameter).getExample();
                     if (abstractSerializableParameterExample == null) {
-                        Map<String, Object> kvs = parameter.getVendorExtensions();
                         abstractSerializableParameterExample = parameter.getVendorExtensions().get("x-example");
                     }
                     if (abstractSerializableParameterExample == null) {

--- a/src/test/java/io/github/swagger2markup/internal/component/PathOperationComponentTest.java
+++ b/src/test/java/io/github/swagger2markup/internal/component/PathOperationComponentTest.java
@@ -15,8 +15,10 @@
  */
 package io.github.swagger2markup.internal.component;
 
+import io.github.swagger2markup.Swagger2MarkupConfig;
 import io.github.swagger2markup.Swagger2MarkupConverter;
 import io.github.swagger2markup.assertions.DiffUtils;
+import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
 import io.github.swagger2markup.internal.resolver.DefinitionDocumentResolverFromOperation;
 import io.github.swagger2markup.internal.resolver.SecurityDocumentResolver;
 import io.github.swagger2markup.internal.utils.PathUtils;
@@ -30,7 +32,9 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class PathOperationComponentTest extends AbstractComponentTest {
@@ -96,5 +100,72 @@ public class PathOperationComponentTest extends AbstractComponentTest {
 
     }
 
+    @Test
+    public void testWithPathParamExample() throws URISyntaxException {
+        String COMPONENT_NAME = "path_operation_with_path_param_example";
+        Path outputDirectory = getOutputFile(COMPONENT_NAME);
+        FileUtils.deleteQuietly(outputDirectory.toFile());
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("swagger2markup.generatedExamplesEnabled", "true");  // enable example
+
+        //Given
+        Path file = Paths.get(PathOperationComponentTest.class.getResource("/yaml/swagger_petstore.yaml").toURI());
+        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder(configMap).build();
+        Swagger2MarkupConverter converter = Swagger2MarkupConverter.from(file).withConfig(config) .build();
+        Swagger swagger = converter.getContext().getSwagger();
+
+        io.swagger.models.Path path = swagger.getPaths().get("/pets/{petId}");
+        List<PathOperation> pathOperations = PathUtils.toPathOperationsList("/pets/{petId}", path);
+
+        Swagger2MarkupConverter.Context context = converter.getContext();
+        MarkupDocBuilder markupDocBuilder = context.createMarkupDocBuilder();
+
+        //When
+        markupDocBuilder = new PathOperationComponent(context,
+                new DefinitionDocumentResolverFromOperation(context),
+                new SecurityDocumentResolver(context)).
+                apply(markupDocBuilder, PathOperationComponent.parameters(pathOperations.get(0)));
+
+        markupDocBuilder.writeToFileWithoutExtension(outputDirectory, StandardCharsets.UTF_8);
+
+        //Then
+        Path expectedFile = getExpectedFile(COMPONENT_NAME);
+        DiffUtils.assertThatFileIsEqual(expectedFile, outputDirectory, getReportName(COMPONENT_NAME));
+    }
+
+    @Test
+    public void testWithQueryParamExample() throws URISyntaxException {
+        String COMPONENT_NAME = "path_operation_with_query_param_example";
+        Path outputDirectory = getOutputFile(COMPONENT_NAME);
+        FileUtils.deleteQuietly(outputDirectory.toFile());
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("swagger2markup.generatedExamplesEnabled", "true");  // enable example
+
+        //Given
+        Path file = Paths.get(PathOperationComponentTest.class.getResource("/yaml/swagger_petstore.yaml").toURI());
+        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder(configMap).build();
+        Swagger2MarkupConverter converter = Swagger2MarkupConverter.from(file).withConfig(config) .build();
+        Swagger swagger = converter.getContext().getSwagger();
+
+        io.swagger.models.Path path = swagger.getPaths().get("/pets/findByTags");
+        List<PathOperation> pathOperations = PathUtils.toPathOperationsList("/pets/findByTags", path);
+
+        Swagger2MarkupConverter.Context context = converter.getContext();
+        MarkupDocBuilder markupDocBuilder = context.createMarkupDocBuilder();
+
+        //When
+        markupDocBuilder = new PathOperationComponent(context,
+                new DefinitionDocumentResolverFromOperation(context),
+                new SecurityDocumentResolver(context)).
+                apply(markupDocBuilder, PathOperationComponent.parameters(pathOperations.get(0)));
+
+        markupDocBuilder.writeToFileWithoutExtension(outputDirectory, StandardCharsets.UTF_8);
+
+        //Then
+        Path expectedFile = getExpectedFile(COMPONENT_NAME);
+        DiffUtils.assertThatFileIsEqual(expectedFile, outputDirectory, getReportName(COMPONENT_NAME));
+    }
 
 }

--- a/src/test/resources/component/path_operation_with_path_param_example.adoc
+++ b/src/test/resources/component/path_operation_with_path_param_example.adoc
@@ -1,0 +1,89 @@
+
+[[_getpetbyid]]
+=== Find pet by ID
+....
+GET /pets/{petId}
+....
+
+
+==== Description
+Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error conditions
+
+
+==== Parameters
+
+[options="header", cols=".^2,.^3,.^9,.^4"]
+|===
+|Type|Name|Description|Schema
+|**Path**|**petId** +
+__required__|ID of pet that needs to be fetched|integer (int64)
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2,.^14,.^4"]
+|===
+|HTTP Code|Description|Schema
+|**200**|successful operation +
+**Headers** :  +
+`X-Rate-Limit-Limit` (integer) : The number of allowed requests in the current period. +
+`X-Rate-Limit-Remaining` (integer) : The number of remaining requests in the current period. +
+`X-Rate-Limit-Reset` (integer) : The number of seconds left in the current period.|<<_pet,Pet>>
+|**400**|Invalid ID supplied|No Content
+|**404**|Pet not found|No Content
+|===
+
+
+==== Produces
+
+* `application/json`
+* `application/xml`
+
+
+==== Tags
+
+* pet
+
+
+==== Security
+
+[options="header", cols=".^3,.^4,.^13"]
+|===
+|Type|Name|Scopes
+|**apiKey**|**<<_api_key,api_key>>**|
+|**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
+|===
+
+
+==== Example HTTP request
+
+===== Request path
+----
+/pets/30
+----
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "id" : 0,
+  "category" : {
+    "id" : 0,
+    "name" : "FoobarCategory"
+  },
+  "name" : "doggie",
+  "photoUrls" : [ "string" ],
+  "tags" : [ {
+    "id" : 0,
+    "name" : "string"
+  } ],
+  "status" : "string"
+}
+----
+
+
+

--- a/src/test/resources/component/path_operation_with_query_param_example.adoc
+++ b/src/test/resources/component/path_operation_with_query_param_example.adoc
@@ -1,0 +1,96 @@
+
+[[_findpetsbytags]]
+=== Finds Pets by tags
+....
+GET /pets/findByTags
+....
+
+
+==== Description
+Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+
+
+==== Parameters
+
+[options="header", cols=".^2,.^3,.^9,.^4"]
+|===
+|Type|Name|Description|Schema
+|**Query**|**tags** +
+__optional__|Tags to filter by|< string > array(multi)
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2,.^14,.^4"]
+|===
+|HTTP Code|Description|Schema
+|**200**|successful operation +
+**Headers** :  +
+`X-Rate-Limit-Limit` (integer) : The number of allowed requests in the current period. +
+`X-Rate-Limit-Remaining` (integer) : The number of remaining requests in the current period. +
+`X-Rate-Limit-Reset` (integer) : The number of seconds left in the current period.|< <<_pet,Pet>> > array
+|**400**|Invalid tag value|No Content
+|===
+
+
+==== Produces
+
+* `application/json`
+* `application/xml`
+
+
+==== Tags
+
+* pet
+
+
+==== Security
+
+[options="header", cols=".^3,.^4,.^13"]
+|===
+|Type|Name|Scopes
+|**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
+|===
+
+
+==== Example HTTP request
+
+===== Request path
+----
+/pets/findByTags
+----
+
+
+===== Request query
+[source,json]
+----
+{
+  "tags" : "adorable"
+}
+----
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+[ {
+  "id" : 0,
+  "category" : {
+    "id" : 0,
+    "name" : "FoobarCategory"
+  },
+  "name" : "doggie",
+  "photoUrls" : [ "string" ],
+  "tags" : [ {
+    "id" : 0,
+    "name" : "string"
+  } ],
+  "status" : "string"
+} ]
+----
+
+
+

--- a/src/test/resources/yaml/swagger_petstore.yaml
+++ b/src/test/resources/yaml/swagger_petstore.yaml
@@ -175,7 +175,7 @@ paths:
           required: true
           type: integer
           format: int64
-          x-exmaple: 30
+          x-example: 30
       responses:
         "404":
           description: Pet not found

--- a/src/test/resources/yaml/swagger_petstore.yaml
+++ b/src/test/resources/yaml/swagger_petstore.yaml
@@ -134,6 +134,7 @@ paths:
           items:
             type: string
           collectionFormat: multi
+          x-example: adorable
       responses:
         "200":
           description: successful operation
@@ -174,6 +175,7 @@ paths:
           required: true
           type: integer
           format: int64
+          x-exmaple: 30
       responses:
         "404":
           description: Pet not found


### PR DESCRIPTION
The adoc output of a path' example always use the default value.For
example in the unit test:

* pets/{petId} use the path params `petId` with example 30, but the
output adoc rendered pets/0 (0 is the default value of int param)
* pets/{findByTags} use the query params `tags` with example adorable,
but the output adoc rendered "tags":"string" ("string" is the default
value of string param)

It should use the "x-example" of the swagger(also the method `example()`
of the swagger-core jar.
This is the first commit to fix this problem, which add the
unit test for it.