### PR TITLE
adoc content in tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,14 @@
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
     }
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
-        classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.10.1'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.6'
+        classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0"
-        classpath "org.ajoberstar:gradle-git:1.3.2"
+        classpath "org.ajoberstar:gradle-git:1.7.2"
     }
 }
 description = 'swagger2markup Build'
@@ -36,7 +35,6 @@ repositories {
         url "https://oss.jfrog.org/artifactory/oss-snapshot-local"
     }
     jcenter()
-    mavenCentral()
     //mavenLocal()
 }
 
@@ -46,12 +44,12 @@ dependencies {
     compile 'org.apache.commons:commons-configuration2:2.1'
     compile 'commons-beanutils:commons-beanutils:1.9.2'
     compile 'org.apache.commons:commons-collections4:4.1'
-    compile 'io.javaslang:javaslang:2.0.5'
-    compile 'ch.netzwerg:paleo-core:0.10.2'
+    compile 'io.vavr:vavr:0.9.1'
+    compile 'ch.netzwerg:paleo-core:0.11.0'
     testCompile 'junit:junit:4.11'
-    testCompile 'org.asciidoctor:asciidoctorj:1.5.4'
+    testCompile 'org.asciidoctor:asciidoctorj:1.5.6'
     testCompile 'ch.qos.logback:logback-classic:1.1.2'
-    testCompile 'org.assertj:assertj-core:3.5.2'
+    testCompile 'org.assertj:assertj-core:3.8.0'
     testCompile 'io.github.robwin:assertj-diff:0.1.1'
 }
 
@@ -66,5 +64,5 @@ test {
 
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '3.3'
+    gradleVersion = '4.2'
 }

--- a/src/main/java/io/github/swagger2markup/internal/component/TableComponent.java
+++ b/src/main/java/io/github/swagger2markup/internal/component/TableComponent.java
@@ -22,9 +22,9 @@ import io.github.swagger2markup.markup.builder.MarkupDocBuilder;
 import io.github.swagger2markup.markup.builder.MarkupLanguage;
 import io.github.swagger2markup.markup.builder.MarkupTableColumn;
 import io.github.swagger2markup.spi.MarkupComponent;
-import javaslang.collection.Array;
-import javaslang.collection.IndexedSeq;
-import javaslang.collection.List;
+import io.vavr.collection.Array;
+import io.vavr.collection.IndexedSeq;
+import io.vavr.collection.List;
 import org.apache.commons.lang3.StringUtils;
 
 
@@ -53,7 +53,7 @@ public class TableComponent extends MarkupComponent<TableComponent.Parameters> {
                     return new MarkupTableColumn(column.getId().getName())
                             .withWidthRatio(widthRatio)
                             .withHeaderColumn(Boolean.parseBoolean(column.getMetaData().get(HEADER_COLUMN).getOrElse("false")))
-                            .withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^" + widthRatio);
+                            .withMarkupSpecifiers(MarkupLanguage.ASCIIDOC, ".^" + widthRatio + "a");
                 }
         ).toJavaList();
 

--- a/src/main/java/io/github/swagger2markup/internal/resolver/DocumentResolver.java
+++ b/src/main/java/io/github/swagger2markup/internal/resolver/DocumentResolver.java
@@ -19,7 +19,7 @@ package io.github.swagger2markup.internal.resolver;
 import io.github.swagger2markup.Swagger2MarkupConfig;
 import io.github.swagger2markup.Swagger2MarkupConverter;
 import io.github.swagger2markup.markup.builder.MarkupDocBuilder;
-import javaslang.Function1;
+import io.vavr.Function1;
 
 /**
  * A functor to return the document part of an inter-document cross-references, depending on the context.

--- a/src/main/java/io/github/swagger2markup/internal/resolver/OperationDocumentResolver.java
+++ b/src/main/java/io/github/swagger2markup/internal/resolver/OperationDocumentResolver.java
@@ -20,7 +20,7 @@ import io.github.swagger2markup.Swagger2MarkupConfig;
 import io.github.swagger2markup.Swagger2MarkupConverter;
 import io.github.swagger2markup.markup.builder.MarkupDocBuilder;
 import io.github.swagger2markup.model.PathOperation;
-import javaslang.Function1;
+import io.vavr.Function1;
 
 /**
  * A functor to return the document part of an inter-document cross-references, depending on the context.

--- a/src/main/java/io/github/swagger2markup/spi/MarkupComponent.java
+++ b/src/main/java/io/github/swagger2markup/spi/MarkupComponent.java
@@ -21,7 +21,7 @@ import io.github.swagger2markup.Swagger2MarkupConfig;
 import io.github.swagger2markup.Swagger2MarkupConverter;
 import io.github.swagger2markup.Swagger2MarkupExtensionRegistry;
 import io.github.swagger2markup.markup.builder.MarkupDocBuilder;
-import javaslang.Function2;
+import io.vavr.Function2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
+++ b/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
@@ -17,9 +17,7 @@ package io.github.swagger2markup;
 
 import io.github.swagger2markup.assertions.DiffUtils;
 import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
-import io.github.swagger2markup.internal.component.ParameterTableComponentTest;
 import io.github.swagger2markup.markup.builder.MarkupLanguage;
-import io.swagger.models.Swagger;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;

--- a/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
+++ b/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
@@ -17,6 +17,9 @@ package io.github.swagger2markup;
 
 import io.github.swagger2markup.assertions.DiffUtils;
 import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
+import io.github.swagger2markup.internal.component.ParameterTableComponentTest;
+import io.github.swagger2markup.markup.builder.MarkupLanguage;
+import io.swagger.models.Swagger;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -520,6 +523,28 @@ public class AsciidocConverterTest {
         Path pathsDirectory = outputDirectory.resolve("operations");
         String[] paths = pathsDirectory.toFile().list();
         assertThat(paths).hasSize(18);
+    }
+
+    @Test
+    public void testWithAsciidocContentInTables() throws URISyntaxException {
+
+        //Given
+        Path file = Paths.get(AsciidocConverterTest.class.getResource("/yaml/swagger_petstore_with_adoc_content.yaml").toURI());
+        Path outputDirectory = Paths.get("build/test/asciidoc/generated");
+        FileUtils.deleteQuietly(outputDirectory.toFile());
+
+        //When
+        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder()
+                .withSwaggerMarkupLanguage(MarkupLanguage.ASCIIDOC)
+                .build();
+
+        Swagger2MarkupConverter.from(file).withConfig(config).build()
+                .toFolder(outputDirectory);
+
+        //Then
+        String[] files = outputDirectory.toFile().list();
+        assertThat(files).hasSize(4).containsAll(expectedFiles);
+
     }
 
     @Test

--- a/src/test/resources/component/definition.adoc
+++ b/src/test/resources/component/definition.adoc
@@ -2,7 +2,7 @@
 [[_pet]]
 === Pet
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +

--- a/src/test/resources/component/parameter_table.adoc
+++ b/src/test/resources/component/parameter_table.adoc
@@ -1,7 +1,7 @@
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +

--- a/src/test/resources/component/path_operation.adoc
+++ b/src/test/resources/component/path_operation.adoc
@@ -8,7 +8,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -18,7 +18,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -46,7 +46,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets

--- a/src/test/resources/component/path_operation_inline_schema.adoc
+++ b/src/test/resources/component/path_operation_inline_schema.adoc
@@ -12,7 +12,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**Option** +
@@ -26,7 +26,7 @@ __optional__|Launch something new|<<_launchcommand_post_launchcommandrequest,Lau
 [[_launchcommand_post_launchcommandrequest]]
 **LaunchCommandRequest**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Command** +
@@ -40,7 +40,7 @@ __optional__|Options k/v pairs|< <<_launchcommand_post_options,Options>> > array
 [[_launchcommand_post_command]]
 **Command**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**args** +
@@ -52,7 +52,7 @@ __optional__|Command path|string
 [[_launchcommand_post_options]]
 **Options**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -64,7 +64,7 @@ __optional__|option value|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result +
@@ -78,7 +78,7 @@ __optional__|option value|string
 [[_launchcommand_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Location** +
@@ -92,7 +92,7 @@ __optional__|<description>|string
 [[_launchcommand_post_options]]
 **Options**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +

--- a/src/test/resources/component/path_operation_with_path_param_example.adoc
+++ b/src/test/resources/component/path_operation_with_path_param_example.adoc
@@ -12,7 +12,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -22,7 +22,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -48,7 +48,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|

--- a/src/test/resources/component/path_operation_with_query_param_example.adoc
+++ b/src/test/resources/component/path_operation_with_query_param_example.adoc
@@ -12,7 +12,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -22,7 +22,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -47,7 +47,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets

--- a/src/test/resources/component/properties_table.adoc
+++ b/src/test/resources/component/properties_table.adoc
@@ -1,5 +1,5 @@
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +

--- a/src/test/resources/component/responses.adoc
+++ b/src/test/resources/component/responses.adoc
@@ -1,7 +1,7 @@
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +

--- a/src/test/resources/component/security_scheme.adoc
+++ b/src/test/resources/component/security_scheme.adoc
@@ -1,7 +1,7 @@
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets

--- a/src/test/resources/component/security_scheme_definition.adoc
+++ b/src/test/resources/component/security_scheme_definition.adoc
@@ -7,7 +7,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.io/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/component/table.adoc
+++ b/src/test/resources/component/table.adoc
@@ -1,5 +1,5 @@
 
-[options="header", cols=".^0,.^0"]
+[options="header", cols=".^0a,.^0a"]
 |===
 |type|name
 |type1|name1

--- a/src/test/resources/expected/asciidoc/basepathprefix/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/basepathprefix/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -18,7 +18,7 @@ __optional__|**Example** : `"Canines"`|string
 [[_complexobject]]
 === ComplexObject
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**subObject** +
@@ -31,7 +31,7 @@ __optional__|**Example** : `{
 [[_subobject]]
 **SubObject**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -44,7 +44,7 @@ __optional__|**Example** : `"a value !"`|string
 [[_identified]]
 === Identified
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -55,7 +55,7 @@ __optional__|**Example** : `0`|integer (int64)
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -79,7 +79,7 @@ __optional__|Order Status +
 Test description
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -108,7 +108,7 @@ __optional__|the weight of the pet +
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -124,7 +124,7 @@ __optional__|**Example** : `"string"`|string
 __Polymorphism__ : Composition
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +

--- a/src/test/resources/expected/asciidoc/basepathprefix/paths.adoc
+++ b/src/test/resources/expected/asciidoc/basepathprefix/paths.adoc
@@ -11,7 +11,7 @@ POST /v2/pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -21,7 +21,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -47,7 +47,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -115,7 +115,7 @@ PUT /v2/pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -125,7 +125,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -153,7 +153,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -205,7 +205,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -215,7 +215,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -236,7 +236,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -299,7 +299,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -309,7 +309,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -330,7 +330,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -389,7 +389,7 @@ POST /v2/pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -403,7 +403,7 @@ __required__|Updated status of the pet|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -428,7 +428,7 @@ __required__|Updated status of the pet|string
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -463,7 +463,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -473,7 +473,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_pet,Pet>>
@@ -495,7 +495,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|
@@ -546,7 +546,7 @@ DELETE /v2/pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -558,7 +558,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -578,7 +578,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -609,7 +609,7 @@ POST /v2/stores/order
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -619,7 +619,7 @@ __optional__|order placed for purchasing the pet|<<_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -689,7 +689,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -699,7 +699,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -756,7 +756,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -766,7 +766,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -806,7 +806,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -816,7 +816,7 @@ __optional__|Created user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -868,7 +868,7 @@ POST /v2/users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -878,7 +878,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -930,7 +930,7 @@ POST /v2/users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -940,7 +940,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -992,7 +992,7 @@ GET /v2/users/login
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Query**|**password** +
@@ -1004,7 +1004,7 @@ __optional__|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|string
@@ -1059,7 +1059,7 @@ GET /v2/users/logout
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -1094,7 +1094,7 @@ GET /v2/users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Path**|**username** +
@@ -1104,7 +1104,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string|`"
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_user,User>>
@@ -1164,7 +1164,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -1176,7 +1176,7 @@ __optional__|Updated user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -1233,7 +1233,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -1243,7 +1243,7 @@ __required__|The name that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/basepathprefix/security.adoc
+++ b/src/test/resources/expected/asciidoc/basepathprefix/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.wordnik.com/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/enums/paths.adoc
+++ b/src/test/resources/expected/asciidoc/enums/paths.adoc
@@ -15,7 +15,7 @@ Return state
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**oldState** +
@@ -27,7 +27,7 @@ __optional__|State as enum in object|<<_createstate_statemodel,StateModel>>
 [[_createstate_statemodel]]
 **StateModel**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**value** +
@@ -37,7 +37,7 @@ __optional__|State value|enum (ADDED, REMOVED, CHANGED)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|enum (ADDED, REMOVED, CHANGED)

--- a/src/test/resources/expected/asciidoc/examples/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/examples/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -18,7 +18,7 @@ __optional__|**Example** : `"Canines"`|string
 [[_complexobject]]
 === ComplexObject
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**subObject** +
@@ -31,7 +31,7 @@ __optional__|**Example** : `{
 [[_subobject]]
 **SubObject**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -44,7 +44,7 @@ __optional__|**Example** : `"a value !"`|string
 [[_identified]]
 === Identified
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -55,7 +55,7 @@ __optional__|integer (int64)
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -79,7 +79,7 @@ __optional__|Order Status +
 Test description
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -104,7 +104,7 @@ __optional__|the weight of the pet|number
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -120,7 +120,7 @@ __optional__|string
 __Polymorphism__ : Composition
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +

--- a/src/test/resources/expected/asciidoc/examples/paths.adoc
+++ b/src/test/resources/expected/asciidoc/examples/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -21,7 +21,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -47,7 +47,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -83,7 +83,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -93,7 +93,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -121,7 +121,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -141,7 +141,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -151,7 +151,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -172,7 +172,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -192,7 +192,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -202,7 +202,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -223,7 +223,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -239,7 +239,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -253,7 +253,7 @@ __required__|Updated status of the pet|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -278,7 +278,7 @@ __required__|Updated status of the pet|string
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -298,7 +298,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -308,7 +308,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_pet,Pet>>
@@ -330,7 +330,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|
@@ -347,7 +347,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -359,7 +359,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -379,7 +379,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -395,7 +395,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -405,7 +405,7 @@ __optional__|order placed for purchasing the pet|<<_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -469,7 +469,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -479,7 +479,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -528,7 +528,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -538,7 +538,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -570,7 +570,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -580,7 +580,7 @@ __optional__|Created user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -607,7 +607,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -617,7 +617,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -644,7 +644,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -654,7 +654,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -681,7 +681,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Query**|**password** +
@@ -693,7 +693,7 @@ __optional__|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|string
@@ -721,7 +721,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -748,7 +748,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Path**|**username** +
@@ -758,7 +758,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string|`"
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_user,User>>
@@ -791,7 +791,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -803,7 +803,7 @@ __optional__|Updated user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -835,7 +835,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -845,7 +845,7 @@ __required__|The name that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/examples/security.adoc
+++ b/src/test/resources/expected/asciidoc/examples/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.wordnik.com/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/format/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/format/definitions.adoc
@@ -10,7 +10,7 @@ __Type__ : < integer (test) > array
 [[_integerobj]]
 === IntegerObj
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +
@@ -31,7 +31,7 @@ __Type__ : < string (test) > array
 [[_stringobj]]
 === StringObj
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +

--- a/src/test/resources/expected/asciidoc/format/paths.adoc
+++ b/src/test/resources/expected/asciidoc/format/paths.adoc
@@ -7,7 +7,7 @@
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**intParam** +
@@ -23,7 +23,7 @@ __required__|test string in query|string (test)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result|string (test)
@@ -37,7 +37,7 @@ __required__|test string in query|string (test)
 [[_c_param_intparam_get_response_201]]
 **Response 201**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +
@@ -47,7 +47,7 @@ __optional__|string (test)
 [[_c_param_intparam_get_response_202]]
 **Response 202**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +
@@ -57,7 +57,7 @@ __optional__|< string (test) > array
 [[_c_param_intparam_get_response_204]]
 **Response 204**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +
@@ -67,7 +67,7 @@ __optional__|integer (test)
 [[_c_param_intparam_get_response_205]]
 **Response 205**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +
@@ -85,7 +85,7 @@ __optional__|< integer (test) > array
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -103,7 +103,7 @@ __required__|test integer str in body|< integer (test) > array
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -113,7 +113,7 @@ __required__|test integer str in body|<<_integerobj_get_body,body>>
 [[_integerobj_get_body]]
 **body**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +
@@ -131,7 +131,7 @@ __optional__|integer (test)
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -149,7 +149,7 @@ __required__|test integer str in body|integer (test)
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -167,7 +167,7 @@ __required__|test string str in body|< string (test) > array
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -177,7 +177,7 @@ __required__|test string str in body|<<_stringobj_get_body,body>>
 [[_stringobj_get_body]]
 **body**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**test** +
@@ -195,7 +195,7 @@ __optional__|string (test)
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +

--- a/src/test/resources/expected/asciidoc/generated/definitions/Category.adoc
+++ b/src/test/resources/expected/asciidoc/generated/definitions/Category.adoc
@@ -2,7 +2,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |*id* +

--- a/src/test/resources/expected/asciidoc/generated/definitions/Order.adoc
+++ b/src/test/resources/expected/asciidoc/generated/definitions/Order.adoc
@@ -2,7 +2,7 @@
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |*complete* +

--- a/src/test/resources/expected/asciidoc/generated/definitions/Pet.adoc
+++ b/src/test/resources/expected/asciidoc/generated/definitions/Pet.adoc
@@ -2,7 +2,7 @@
 [[_pet]]
 === Pet
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |*category* +

--- a/src/test/resources/expected/asciidoc/generated/definitions/Tag.adoc
+++ b/src/test/resources/expected/asciidoc/generated/definitions/Tag.adoc
@@ -2,7 +2,7 @@
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |*id* +

--- a/src/test/resources/expected/asciidoc/generated/definitions/User.adoc
+++ b/src/test/resources/expected/asciidoc/generated/definitions/User.adoc
@@ -2,7 +2,7 @@
 [[_user]]
 === User
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |*email* +

--- a/src/test/resources/expected/asciidoc/generated/paths.adoc
+++ b/src/test/resources/expected/asciidoc/generated/paths.adoc
@@ -7,7 +7,7 @@
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|string

--- a/src/test/resources/expected/asciidoc/generated_examples/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -18,7 +18,7 @@ __optional__|**Example** : `"Canines"`|string
 [[_complexobject]]
 === ComplexObject
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**subObject** +
@@ -31,7 +31,7 @@ __optional__|**Example** : `{
 [[_subobject]]
 **SubObject**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -44,7 +44,7 @@ __optional__|**Example** : `"a value !"`|string
 [[_identified]]
 === Identified
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -55,7 +55,7 @@ __optional__|**Example** : `0`|integer (int64)
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -79,7 +79,7 @@ __optional__|Order Status +
 Test description
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -108,7 +108,7 @@ __optional__|the weight of the pet +
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -124,7 +124,7 @@ __optional__|**Example** : `"string"`|string
 __Polymorphism__ : Composition
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +

--- a/src/test/resources/expected/asciidoc/generated_examples/paths.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -21,7 +21,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -47,7 +47,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -115,7 +115,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -125,7 +125,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -153,7 +153,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -205,7 +205,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -215,7 +215,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -236,7 +236,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -299,7 +299,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -309,7 +309,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -330,7 +330,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -389,7 +389,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -403,7 +403,7 @@ __required__|Updated status of the pet|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -428,7 +428,7 @@ __required__|Updated status of the pet|string
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -463,7 +463,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -473,7 +473,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_pet,Pet>>
@@ -495,7 +495,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|
@@ -546,7 +546,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -558,7 +558,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -578,7 +578,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -609,7 +609,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -619,7 +619,7 @@ __optional__|order placed for purchasing the pet|<<_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -689,7 +689,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -699,7 +699,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -756,7 +756,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -766,7 +766,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -806,7 +806,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -816,7 +816,7 @@ __optional__|Created user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -868,7 +868,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -878,7 +878,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -930,7 +930,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -940,7 +940,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -992,7 +992,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Query**|**password** +
@@ -1004,7 +1004,7 @@ __optional__|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|string
@@ -1059,7 +1059,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -1094,7 +1094,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Path**|**username** +
@@ -1104,7 +1104,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string|`"
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_user,User>>
@@ -1164,7 +1164,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -1176,7 +1176,7 @@ __optional__|Updated user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -1233,7 +1233,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -1243,7 +1243,7 @@ __required__|The name that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/generated_examples/security.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.wordnik.com/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/generated_recursion_examples/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/generated_recursion_examples/definitions.adoc
@@ -5,7 +5,7 @@
 [[_navigationentry]]
 === NavigationEntry
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**childs** +

--- a/src/test/resources/expected/asciidoc/generated_recursion_examples/paths.adoc
+++ b/src/test/resources/expected/asciidoc/generated_recursion_examples/paths.adoc
@@ -15,7 +15,7 @@ Returns the navigation as a tree
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Successful response|<<_navigationentry,NavigationEntry>>
@@ -63,7 +63,7 @@ Updates the navigation tree
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^4"]
+[options="header", cols=".^2a,.^3a,.^4a"]
 |===
 |Type|Name|Schema
 |**Body**|**entry** +
@@ -73,7 +73,7 @@ __optional__|<<_navigationentry,NavigationEntry>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Successful response|<<_navigationentry,NavigationEntry>>

--- a/src/test/resources/expected/asciidoc/group_by_tags/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/group_by_tags/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -22,7 +22,7 @@ __optional__|The name of the category +
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -46,7 +46,7 @@ __optional__|Order Status|enum (Ordered, Cancelled)
 [[_pet]]
 === Pet
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -67,7 +67,7 @@ __optional__||< <<_tag,Tag>> > array
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -80,7 +80,7 @@ __optional__|string
 [[_user]]
 === User
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +

--- a/src/test/resources/expected/asciidoc/group_by_tags/paths.adoc
+++ b/src/test/resources/expected/asciidoc/group_by_tags/paths.adoc
@@ -16,7 +16,7 @@ POST /pets
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -26,7 +26,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -47,7 +47,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ===== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -63,7 +63,7 @@ PUT /pets
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -73,7 +73,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -96,7 +96,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ===== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -116,7 +116,7 @@ Multiple status values can be provided with comma seperated strings
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -126,7 +126,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -146,7 +146,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ===== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -166,7 +166,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -176,7 +176,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -196,7 +196,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ===== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -212,7 +212,7 @@ POST /pets/{petId}
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -226,7 +226,7 @@ __required__|Updated status of the pet|string
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -246,7 +246,7 @@ __required__|Updated status of the pet|string
 
 ===== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -266,7 +266,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -276,7 +276,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -297,7 +297,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ===== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|
@@ -314,7 +314,7 @@ DELETE /pets/{petId}
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -326,7 +326,7 @@ __required__|Pet id to delete|integer (int64)
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -341,7 +341,7 @@ __required__|Pet id to delete|integer (int64)
 
 ===== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -362,7 +362,7 @@ POST /stores/order
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -372,7 +372,7 @@ __optional__|order placed for purchasing the pet|<<_order,Order>>
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -403,7 +403,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -413,7 +413,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -445,7 +445,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -455,7 +455,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -487,7 +487,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -497,7 +497,7 @@ __optional__|Created user object|<<_user,User>>
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -519,7 +519,7 @@ POST /users/createWithArray
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -529,7 +529,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -551,7 +551,7 @@ POST /users/createWithList
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -561,7 +561,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -583,7 +583,7 @@ GET /users/login
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**password** +
@@ -595,7 +595,7 @@ __optional__|The user name for login|string
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -622,7 +622,7 @@ GET /users/logout
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -644,7 +644,7 @@ GET /users/{username}
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -654,7 +654,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -686,7 +686,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -698,7 +698,7 @@ __optional__|Updated user object|<<_user,User>>
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -725,7 +725,7 @@ This can only be done by the logged in user.
 
 ===== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -735,7 +735,7 @@ __required__|The name that needs to be deleted|string
 
 ===== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/group_by_tags/security.adoc
+++ b/src/test/resources/expected/asciidoc/group_by_tags/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.io/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/idxref/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/idxref/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -22,7 +22,7 @@ __optional__|The name of the category +
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -46,7 +46,7 @@ __optional__|Order Status|enum (Ordered, Cancelled)
 [[_pet]]
 === Pet
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -67,7 +67,7 @@ __optional__||< <<definitions.adoc#_tag,Tag>> > array
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -80,7 +80,7 @@ __optional__|string
 [[_user]]
 === User
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +

--- a/src/test/resources/expected/asciidoc/idxref/paths.adoc
+++ b/src/test/resources/expected/asciidoc/idxref/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -21,7 +21,7 @@ __optional__|Pet object that needs to be added to the store|<<definitions.adoc#_
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -47,7 +47,7 @@ __optional__|Pet object that needs to be added to the store|<<definitions.adoc#_
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<security.adoc#_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -63,7 +63,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -73,7 +73,7 @@ __optional__|Pet object that needs to be added to the store|<<definitions.adoc#_
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -101,7 +101,7 @@ __optional__|Pet object that needs to be added to the store|<<definitions.adoc#_
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<security.adoc#_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -121,7 +121,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -131,7 +131,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -156,7 +156,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<security.adoc#_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -176,7 +176,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -186,7 +186,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -211,7 +211,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<security.adoc#_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -227,7 +227,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -241,7 +241,7 @@ __required__|Updated status of the pet|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -266,7 +266,7 @@ __required__|Updated status of the pet|string
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<security.adoc#_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -286,7 +286,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -296,7 +296,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -322,7 +322,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<security.adoc#_api_key,api_key>>**|
@@ -339,7 +339,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -351,7 +351,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -371,7 +371,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<security.adoc#_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -387,7 +387,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -397,7 +397,7 @@ __optional__|order placed for purchasing the pet|<<definitions.adoc#_order,Order
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -433,7 +433,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -443,7 +443,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -480,7 +480,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -490,7 +490,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -522,7 +522,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -532,7 +532,7 @@ __optional__|Created user object|<<definitions.adoc#_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -559,7 +559,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -569,7 +569,7 @@ __optional__|List of user object|< <<definitions.adoc#_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -596,7 +596,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -606,7 +606,7 @@ __optional__|List of user object|< <<definitions.adoc#_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -633,7 +633,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**password** +
@@ -645,7 +645,7 @@ __optional__|The user name for login|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -677,7 +677,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -704,7 +704,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -714,7 +714,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -751,7 +751,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -763,7 +763,7 @@ __optional__|Updated user object|<<definitions.adoc#_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -795,7 +795,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -805,7 +805,7 @@ __required__|The name that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/idxref/security.adoc
+++ b/src/test/resources/expected/asciidoc/idxref/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.io/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/inline_schema/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema/definitions.adoc
@@ -5,7 +5,7 @@
 [[_error]]
 === Error
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**error-code** +
@@ -18,7 +18,7 @@ __optional__|Error message|string
 [[_inlinedepthschema]]
 === InlineDepthSchema
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**Loop** +
@@ -28,7 +28,7 @@ __optional__|<<_inlinedepthschema_loop,Loop>>
 [[_inlinedepthschema_loop]]
 **Loop**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p1** +
@@ -40,7 +40,7 @@ __optional__|Description p2|<<_inlinedepthschema_p2,p2>>
 [[_inlinedepthschema_p2]]
 **p2**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-1** +
@@ -52,7 +52,7 @@ __optional__|Description p2-2|<<_inlinedepthschema_p2_p2-2,p2-2>>
 [[_inlinedepthschema_p2_p2-2]]
 **p2-2**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-2-1** +
@@ -64,7 +64,7 @@ __optional__|Description p2-2-2|<<_inlinedepthschema_p2_p2-2_p2-2-2,p2-2-2>>
 [[_inlinedepthschema_p2_p2-2_p2-2-1]]
 **p2-2-1**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-2-1-1** +
@@ -76,7 +76,7 @@ __optional__|Description p2-2-1-2|boolean
 [[_inlinedepthschema_p2_p2-2_p2-2-2]]
 **p2-2-2**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-2-2-1** +
@@ -89,7 +89,7 @@ __optional__|Description p2-2-2-2|boolean
 [[_inlinepet]]
 === InlinePet
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**category** +
@@ -103,7 +103,7 @@ __optional__|< <<_inlinepet_tags,tags>> > array
 [[_inlinepet_category]]
 **category**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -115,7 +115,7 @@ __optional__|string
 [[_inlinepet_tags]]
 **tags**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -128,7 +128,7 @@ __optional__|string
 [[_inlinetitlepet]]
 === InlineTitlePet
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**category** +
@@ -142,7 +142,7 @@ __optional__|< <<_tagmodel,TagModel>> > array
 [[_categorymodel]]
 **CategoryModel**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -154,7 +154,7 @@ __optional__|string
 [[_tagmodel]]
 **TagModel**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -167,7 +167,7 @@ __optional__|string
 [[_location]]
 === Location
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Place** +
@@ -180,7 +180,7 @@ __optional__|Place|string
 mixed collections and objects
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -190,7 +190,7 @@ __optional__|< <<_mixedschema_mytable,myTable>> > array
 [[_mixedschema_mytable]]
 **myTable**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -200,7 +200,7 @@ __optional__|< string, <<_mixedschema_mydict,myDict>> > map
 [[_mixedschema_mydict]]
 **myDict**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -219,7 +219,7 @@ __Type__ : < < string, <<_recursivecollectionschema_inline,RecursiveCollectionSc
 [[_recursivecollectionschema_inline]]
 **RecursiveCollectionSchema**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -234,7 +234,7 @@ __optional__|option value|string
 mixed collections and objects
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -244,7 +244,7 @@ __optional__|< <<_tablecontent,TableContent>> > array
 [[_tablecontent]]
 **TableContent**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**emptyObject** +
@@ -256,7 +256,7 @@ __optional__|< string, <<_kvpair,KVPair>> > map
 [[_kvpair]]
 **KVPair**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +

--- a/src/test/resources/expected/asciidoc/inline_schema/paths.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema/paths.adoc
@@ -15,7 +15,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**Version** +
@@ -25,7 +25,7 @@ __optional__|The API version|< < string, <<_collectionparameters_post_version,Ve
 [[_collectionparameters_post_version]]
 **Version**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -37,7 +37,7 @@ __optional__|option value|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result|< < string, <<_collectionparameters_post_response_200,Response 200>> > map > array
@@ -46,7 +46,7 @@ __optional__|option value|string
 [[_collectionparameters_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -74,7 +74,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**Option** +
@@ -88,7 +88,7 @@ __optional__|Launch something new|<<_launchcommand_post_launchcommandrequest,Lau
 [[_launchcommand_post_launchcommandrequest]]
 **LaunchCommandRequest**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Command** +
@@ -102,7 +102,7 @@ __optional__|Options k/v pairs|< <<_launchcommand_post_options,Options>> > array
 [[_launchcommand_post_command]]
 **Command**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**args** +
@@ -114,7 +114,7 @@ __optional__|Command path|string
 [[_launchcommand_post_options]]
 **Options**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -126,7 +126,7 @@ __optional__|option value|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result +
@@ -140,7 +140,7 @@ __optional__|option value|string
 [[_launchcommand_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Location** +
@@ -154,7 +154,7 @@ __optional__|<description>|string
 [[_launchcommand_post_options]]
 **Options**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -182,7 +182,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**Version** +
@@ -192,7 +192,7 @@ __optional__|The API version|<<_mixedparameters_post_version,Version>>
 [[_mixedparameters_post_version]]
 **Version**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -202,7 +202,7 @@ __optional__|< <<_mixedparameters_post_mytable,myTable>> > array
 [[_mixedparameters_post_mytable]]
 **myTable**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -212,7 +212,7 @@ __optional__|< string, <<_mixedparameters_post_mytable_mydict,myDict>> > map
 [[_mixedparameters_post_mytable_mydict]]
 **myDict**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -224,7 +224,7 @@ __optional__|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result|<<_mixedparameters_post_response_200,Response 200>>
@@ -233,7 +233,7 @@ __optional__|string
 [[_mixedparameters_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -243,7 +243,7 @@ __optional__|< <<_mixedparameters_post_mytable,myTable>> > array
 [[_mixedparameters_post_mytable]]
 **myTable**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -253,7 +253,7 @@ __optional__|< string, <<_mixedparameters_post_mytable_mydict,myDict>> > map
 [[_mixedparameters_post_mytable_mydict]]
 **myDict**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -281,7 +281,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**Version** +
@@ -291,7 +291,7 @@ __optional__|The API version|<<_request,Request>>
 [[_request]]
 **Request**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -301,7 +301,7 @@ __optional__|< <<_tablecontent,TableContent>> > array
 [[_tablecontent]]
 **TableContent**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -311,7 +311,7 @@ __optional__|< string, <<_kvpair,KVPair>> > map
 [[_kvpair]]
 **KVPair**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -323,7 +323,7 @@ __optional__|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result|<<_result,Result>>
@@ -332,7 +332,7 @@ __optional__|string
 [[_result]]
 **Result**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -342,7 +342,7 @@ __optional__|< <<_tablecontent,TableContent>> > array
 [[_tablecontent]]
 **TableContent**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -352,7 +352,7 @@ __optional__|< string, <<_kvpair,KVPair>> > map
 [[_kvpair]]
 **KVPair**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +

--- a/src/test/resources/expected/asciidoc/inline_schema_flat_body/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema_flat_body/definitions.adoc
@@ -5,7 +5,7 @@
 [[_error]]
 === Error
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**error-code** +
@@ -18,7 +18,7 @@ __optional__|Error message|string
 [[_inlinedepthschema]]
 === InlineDepthSchema
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**Loop** +
@@ -28,7 +28,7 @@ __optional__|<<_inlinedepthschema_loop,Loop>>
 [[_inlinedepthschema_loop]]
 **Loop**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p1** +
@@ -40,7 +40,7 @@ __optional__|Description p2|<<_inlinedepthschema_p2,p2>>
 [[_inlinedepthschema_p2]]
 **p2**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-1** +
@@ -52,7 +52,7 @@ __optional__|Description p2-2|<<_inlinedepthschema_p2_p2-2,p2-2>>
 [[_inlinedepthschema_p2_p2-2]]
 **p2-2**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-2-1** +
@@ -64,7 +64,7 @@ __optional__|Description p2-2-2|<<_inlinedepthschema_p2_p2-2_p2-2-2,p2-2-2>>
 [[_inlinedepthschema_p2_p2-2_p2-2-1]]
 **p2-2-1**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-2-1-1** +
@@ -76,7 +76,7 @@ __optional__|Description p2-2-1-2|boolean
 [[_inlinedepthschema_p2_p2-2_p2-2-2]]
 **p2-2-2**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**p2-2-2-1** +
@@ -89,7 +89,7 @@ __optional__|Description p2-2-2-2|boolean
 [[_inlinepet]]
 === InlinePet
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**category** +
@@ -103,7 +103,7 @@ __optional__|< <<_inlinepet_tags,tags>> > array
 [[_inlinepet_category]]
 **category**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -115,7 +115,7 @@ __optional__|string
 [[_inlinepet_tags]]
 **tags**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -128,7 +128,7 @@ __optional__|string
 [[_inlinetitlepet]]
 === InlineTitlePet
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**category** +
@@ -142,7 +142,7 @@ __optional__|< <<_tagmodel,TagModel>> > array
 [[_categorymodel]]
 **CategoryModel**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -154,7 +154,7 @@ __optional__|string
 [[_tagmodel]]
 **TagModel**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -167,7 +167,7 @@ __optional__|string
 [[_location]]
 === Location
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Place** +
@@ -180,7 +180,7 @@ __optional__|Place|string
 mixed collections and objects
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -190,7 +190,7 @@ __optional__|< <<_mixedschema_mytable,myTable>> > array
 [[_mixedschema_mytable]]
 **myTable**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -200,7 +200,7 @@ __optional__|< string, <<_mixedschema_mydict,myDict>> > map
 [[_mixedschema_mydict]]
 **myDict**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -219,7 +219,7 @@ __Type__ : < < string, <<_recursivecollectionschema_inline,RecursiveCollectionSc
 [[_recursivecollectionschema_inline]]
 **RecursiveCollectionSchema**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -234,7 +234,7 @@ __optional__|option value|string
 mixed collections and objects
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -244,7 +244,7 @@ __optional__|< <<_tablecontent,TableContent>> > array
 [[_tablecontent]]
 **TableContent**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**emptyObject** +
@@ -256,7 +256,7 @@ __optional__|< string, <<_kvpair,KVPair>> > map
 [[_kvpair]]
 **KVPair**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +

--- a/src/test/resources/expected/asciidoc/inline_schema_flat_body/paths.adoc
+++ b/src/test/resources/expected/asciidoc/inline_schema_flat_body/paths.adoc
@@ -24,7 +24,7 @@ __Type__ : < < string, <<_collectionparameters_post_version,Version>> > map > ar
 [[_collectionparameters_post_version]]
 **Version**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -36,7 +36,7 @@ __optional__|option value|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result|< < string, <<_collectionparameters_post_response_200,Response 200>> > map > array
@@ -45,7 +45,7 @@ __optional__|option value|string
 [[_collectionparameters_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -73,7 +73,7 @@ Dummy description
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**Option** +
@@ -91,7 +91,7 @@ __Name__ : LaunchCommandRequest
 __Flags__ : optional
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Command** +
@@ -105,7 +105,7 @@ __optional__|Options k/v pairs|< <<_launchcommand_post_options,Options>> > array
 [[_launchcommand_post_command]]
 **Command**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**args** +
@@ -117,7 +117,7 @@ __optional__|Command path|string
 [[_launchcommand_post_options]]
 **Options**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -129,7 +129,7 @@ __optional__|option value|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result +
@@ -143,7 +143,7 @@ __optional__|option value|string
 [[_launchcommand_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**Location** +
@@ -157,7 +157,7 @@ __optional__|<description>|string
 [[_launchcommand_post_options]]
 **Options**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**key** +
@@ -191,7 +191,7 @@ __Name__ : Version
 __Flags__ : optional
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -201,7 +201,7 @@ __optional__|< <<_mixedparameters_post_mytable,myTable>> > array
 [[_mixedparameters_post_mytable]]
 **myTable**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -211,7 +211,7 @@ __optional__|< string, <<_mixedparameters_post_mydict,myDict>> > map
 [[_mixedparameters_post_mydict]]
 **myDict**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -223,7 +223,7 @@ __optional__|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result|<<_mixedparameters_post_response_200,Response 200>>
@@ -232,7 +232,7 @@ __optional__|string
 [[_mixedparameters_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -242,7 +242,7 @@ __optional__|< <<_mixedparameters_post_mytable,myTable>> > array
 [[_mixedparameters_post_mytable]]
 **myTable**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -252,7 +252,7 @@ __optional__|< string, <<_mixedparameters_post_mytable_mydict,myDict>> > map
 [[_mixedparameters_post_mytable_mydict]]
 **myDict**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -286,7 +286,7 @@ __Name__ : Version
 __Flags__ : optional
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -296,7 +296,7 @@ __optional__|< <<_tablecontent,TableContent>> > array
 [[_tablecontent]]
 **TableContent**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -306,7 +306,7 @@ __optional__|< string, <<_kvpair,KVPair>> > map
 [[_kvpair]]
 **KVPair**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +
@@ -318,7 +318,7 @@ __optional__|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Result|<<_result,Result>>
@@ -327,7 +327,7 @@ __optional__|string
 [[_result]]
 **Result**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myTable** +
@@ -337,7 +337,7 @@ __optional__|< <<_tablecontent,TableContent>> > array
 [[_tablecontent]]
 **TableContent**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**myDict** +
@@ -347,7 +347,7 @@ __optional__|< string, <<_kvpair,KVPair>> > map
 [[_kvpair]]
 **KVPair**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**k** +

--- a/src/test/resources/expected/asciidoc/instagram/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/instagram/definitions.adoc
@@ -5,7 +5,7 @@
 [[_comment]]
 === Comment
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**created_time** +
@@ -22,7 +22,7 @@ __optional__|string
 [[_image]]
 === Image
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**height** +
@@ -37,7 +37,7 @@ __optional__|integer
 [[_like]]
 === Like
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**first_name** +
@@ -56,7 +56,7 @@ __optional__|string
 [[_location]]
 === Location
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -73,7 +73,7 @@ __optional__|string
 [[_media]]
 === Media
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**comments:** +
@@ -105,7 +105,7 @@ __optional__||<<_media_videos,videos>>
 [[_media_comments]]
 **comments:**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**count** +
@@ -117,7 +117,7 @@ __optional__|< <<_comment,Comment>> > array
 [[_media_images]]
 **images**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**low_resolution** +
@@ -131,7 +131,7 @@ __optional__|<<_image,Image>>
 [[_media_likes]]
 **likes**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**count** +
@@ -143,7 +143,7 @@ __optional__|< <<_miniprofile,MiniProfile>> > array
 [[_media_videos]]
 **videos**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**low_resolution** +
@@ -158,7 +158,7 @@ __optional__|<<_image,Image>>
 A shorter version of User for likes array
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**full_name** +
@@ -175,7 +175,7 @@ __optional__|string
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**media_count** +
@@ -188,7 +188,7 @@ __optional__|string
 [[_user]]
 === User
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**bio** +
@@ -210,7 +210,7 @@ __optional__|string
 [[_user_counts]]
 **counts**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**follows** +

--- a/src/test/resources/expected/asciidoc/instagram/paths.adoc
+++ b/src/test/resources/expected/asciidoc/instagram/paths.adoc
@@ -19,7 +19,7 @@ geography, use the https://instagram.com/developer/endpoints/media/[media search
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**geo-id** +
@@ -33,7 +33,7 @@ __optional__|Return media before this `min_id`.|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|No Content
@@ -54,7 +54,7 @@ Search for a location by geographic coordinate.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**distance** +
@@ -79,7 +79,7 @@ __optional__|ongitude of the center search coordinate. If used, lat is required.
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_locations_search_get_response_200,Response 200>>
@@ -88,7 +88,7 @@ __optional__|ongitude of the center search coordinate. If used, lat is required.
 [[_locations_search_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -110,7 +110,7 @@ Get information about a location.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**location-id** +
@@ -120,7 +120,7 @@ __required__|Location ID|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_locations_location-id_get_response_200,Response 200>>
@@ -129,7 +129,7 @@ __required__|Location ID|integer
 [[_locations_location-id_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -151,7 +151,7 @@ Get a list of recent media objects from a given location.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**location-id** +
@@ -169,7 +169,7 @@ __optional__|Return media after this UNIX timestamp.|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_locations_location-id_media_recent_get_response_200,Response 200>>
@@ -178,7 +178,7 @@ __optional__|Return media after this UNIX timestamp.|integer
 [[_locations_location-id_media_recent_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -202,7 +202,7 @@ Can return mix of image and video types.
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_popular_get_response_200,Response 200>>
@@ -211,7 +211,7 @@ Can return mix of image and video types.
 [[_media_popular_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -235,7 +235,7 @@ the last 5 days. Can return mix of image and video types.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Query**|**DISTANCE** +
@@ -255,7 +255,7 @@ this timestamp.|integer|
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_search_get_response_200,Response 200>>
@@ -264,7 +264,7 @@ this timestamp.|integer|
 [[_media_search_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -292,7 +292,7 @@ has liked this media item.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**media-id** +
@@ -302,7 +302,7 @@ __required__|The media ID|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media,Media>>
@@ -328,7 +328,7 @@ Create a comment on a media object with the following rules:
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**media-id** +
@@ -341,7 +341,7 @@ media-id.|number
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_media-id_comments_post_response_200,Response 200>>
@@ -350,7 +350,7 @@ media-id.|number
 [[_media_media-id_comments_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -362,7 +362,7 @@ __optional__|<<_media_media-id_comments_post_meta,meta>>
 [[_media_media-id_comments_post_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -378,7 +378,7 @@ __optional__|number
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_oauth,oauth>>**|comments
@@ -394,7 +394,7 @@ Get a list of recent comments on a media object.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**media-id** +
@@ -404,7 +404,7 @@ __required__|Media ID|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_media-id_comments_get_response_200,Response 200>>
@@ -413,7 +413,7 @@ __required__|Media ID|integer
 [[_media_media-id_comments_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -425,7 +425,7 @@ __optional__|<<_media_media-id_comments_get_meta,meta>>
 [[_media_media-id_comments_get_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -448,7 +448,7 @@ authored by the authenticated user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**media-id** +
@@ -458,7 +458,7 @@ __required__|Media ID|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_media-id_comments_delete_response_200,Response 200>>
@@ -467,7 +467,7 @@ __required__|Media ID|integer
 [[_media_media-id_comments_delete_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -479,7 +479,7 @@ __optional__|<<_media_media-id_comments_delete_meta,meta>>
 [[_media_media-id_comments_delete_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -501,7 +501,7 @@ Set a like on this media by the currently authenticated user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**media-id** +
@@ -511,7 +511,7 @@ __required__|Media ID|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_media-id_likes_post_response_200,Response 200>>
@@ -520,7 +520,7 @@ __required__|Media ID|integer
 [[_media_media-id_likes_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -532,7 +532,7 @@ __optional__|<<_media_media-id_likes_post_meta,meta>>
 [[_media_media-id_likes_post_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -547,7 +547,7 @@ __optional__|number
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_oauth,oauth>>**|comments
@@ -563,7 +563,7 @@ Get a list of users who have liked this media.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**media-id** +
@@ -573,7 +573,7 @@ __required__|Media ID|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_media-id_likes_get_response_200,Response 200>>
@@ -582,7 +582,7 @@ __required__|Media ID|integer
 [[_media_media-id_likes_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -594,7 +594,7 @@ __optional__|<<_media_media-id_likes_get_meta,meta>>
 [[_media_media-id_likes_get_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -617,7 +617,7 @@ Remove a like on this media by the currently authenticated user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**media-id** +
@@ -627,7 +627,7 @@ __required__|Media ID|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media_media-id_likes_delete_response_200,Response 200>>
@@ -636,7 +636,7 @@ __required__|Media ID|integer
 [[_media_media-id_likes_delete_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -648,7 +648,7 @@ __optional__|<<_media_media-id_likes_delete_meta,meta>>
 [[_media_media-id_likes_delete_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -674,7 +674,7 @@ Its corresponding shortcode is D.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**shortcode** +
@@ -684,7 +684,7 @@ __required__|The media shortcode|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_media,Media>>
@@ -701,7 +701,7 @@ __required__|The media shortcode|string
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**q** +
@@ -711,7 +711,7 @@ __optional__|A valid tag name without a leading #. (eg. snowy, nofilter)|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_tags_search_get_response_200,Response 200>>
@@ -720,7 +720,7 @@ __optional__|A valid tag name without a leading #. (eg. snowy, nofilter)|string
 [[_tags_search_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -732,7 +732,7 @@ __optional__|<<_tags_search_get_meta,meta>>
 [[_tags_search_get_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -754,7 +754,7 @@ Get information about a tag object.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**tag-name** +
@@ -764,7 +764,7 @@ __required__|Tag name|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_tag,Tag>>
@@ -787,7 +787,7 @@ these objects.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**tag-name** +
@@ -797,7 +797,7 @@ __required__|Tag name|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_tags_tag-name_media_recent_get_response_200,Response 200>>
@@ -806,7 +806,7 @@ __required__|Tag name|string
 [[_tags_tag-name_media_recent_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -828,7 +828,7 @@ Search for a user by name.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**count** +
@@ -840,7 +840,7 @@ __required__|A query string|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_users_search_get_response_200,Response 200>>
@@ -849,7 +849,7 @@ __required__|A query string|string
 [[_users_search_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -871,7 +871,7 @@ See the authenticated user's feed.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**count** +
@@ -885,7 +885,7 @@ __optional__|Return media later than this min_id.|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_users_self_feed_get_response_200,Response 200>>
@@ -894,7 +894,7 @@ __optional__|Return media later than this min_id.|integer
 [[_users_self_feed_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -919,7 +919,7 @@ available for the currently authenticated user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**count** +
@@ -931,7 +931,7 @@ __optional__|Return media liked before this id.|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_users_self_media_liked_get_response_200,Response 200>>
@@ -940,7 +940,7 @@ __optional__|Return media liked before this id.|integer
 [[_users_self_media_liked_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -962,7 +962,7 @@ List the users who have requested this user's permission to follow.
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_users_self_requested-by_get_response_200,Response 200>>
@@ -971,7 +971,7 @@ List the users who have requested this user's permission to follow.
 [[_users_self_requested-by_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -983,7 +983,7 @@ __optional__|<<_users_self_requested-by_get_meta,meta>>
 [[_users_self_requested-by_get_meta]]
 **meta**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**code** +
@@ -1005,7 +1005,7 @@ Get basic information about a user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**user-id** +
@@ -1015,7 +1015,7 @@ __required__|The user identifier number|number
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|The user object|<<_users_user-id_get_response_200,Response 200>>
@@ -1024,7 +1024,7 @@ __required__|The user identifier number|number
 [[_users_user-id_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -1039,7 +1039,7 @@ __optional__|<<_user,User>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_key,key>>**|
@@ -1056,7 +1056,7 @@ Get the list of users this user is followed by.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**user-id** +
@@ -1066,7 +1066,7 @@ __required__|The user identifier number|number
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_users_user-id_followed-by_get_response_200,Response 200>>
@@ -1075,7 +1075,7 @@ __required__|The user identifier number|number
 [[_users_user-id_followed-by_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -1097,7 +1097,7 @@ Get the list of users this user follows.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**user-id** +
@@ -1107,7 +1107,7 @@ __required__|The user identifier number|number
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_users_user-id_follows_get_response_200,Response 200>>
@@ -1116,7 +1116,7 @@ __required__|The user identifier number|number
 [[_users_user-id_follows_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -1134,7 +1134,7 @@ __optional__|< <<_miniprofile,MiniProfile>> > array
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**user-id** +
@@ -1154,7 +1154,7 @@ __optional__|Return media after this UNIX timestamp.|integer
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|Get the most recent media published by a user. To get the most recent
@@ -1165,7 +1165,7 @@ instead of the `user-id`.|<<_users_user-id_media_recent_get_response_200,Respons
 [[_users_user-id_media_recent_get_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -1187,7 +1187,7 @@ Modify the relationship between the current user and thetarget user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**user-id** +
@@ -1199,7 +1199,7 @@ __optional__|One of follow/unfollow/block/unblock/approve/ignore.|enum (follow, 
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_users_user-id_relationship_post_response_200,Response 200>>
@@ -1208,7 +1208,7 @@ __optional__|One of follow/unfollow/block/unblock/approve/ignore.|enum (follow, 
 [[_users_user-id_relationship_post_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**data** +
@@ -1223,7 +1223,7 @@ __optional__|< <<_miniprofile,MiniProfile>> > array
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_oauth,oauth>>**|relationships

--- a/src/test/resources/expected/asciidoc/instagram/security.adoc
+++ b/src/test/resources/expected/asciidoc/instagram/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |basic|to read any and all data related to a user (e.g. following/followed-by

--- a/src/test/resources/expected/asciidoc/maps/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/maps/definitions.adoc
@@ -7,7 +7,7 @@
 Information about a given HTTP mapping.
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**bean** +

--- a/src/test/resources/expected/asciidoc/maps/paths.adoc
+++ b/src/test/resources/expected/asciidoc/maps/paths.adoc
@@ -15,7 +15,7 @@ Returns integer metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -25,7 +25,7 @@ __optional__|String metrics|< string, integer (int32) > map
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|< string, string > map
@@ -60,7 +60,7 @@ Returns a collated list of all `@RequestMapping` paths.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -70,7 +70,7 @@ __optional__|Mappings|< string, <<_mappinginfo,MappingInfo>> > map
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|< string, <<_mappinginfo,MappingInfo>> > map
@@ -105,7 +105,7 @@ Returns metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -115,7 +115,7 @@ __optional__|Metrics|< string, <<_createmetrics_body,body>> > map
 [[_createmetrics_body]]
 **body**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**p1** +
@@ -127,7 +127,7 @@ __optional__|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|< string, <<_createmetrics_response_200,Response 200>> > map
@@ -136,7 +136,7 @@ __optional__|string
 [[_createmetrics_response_200]]
 **Response 200**
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**p1** +
@@ -174,7 +174,7 @@ Returns string metrics information for the application.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -184,7 +184,7 @@ __optional__|String metrics|< string, string > map
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|< string, string > map

--- a/src/test/resources/expected/asciidoc/page_breaks/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/page_breaks/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -18,7 +18,7 @@ __optional__|**Example** : `"Canines"`|string
 [[_complexobject]]
 === ComplexObject
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**subObject** +
@@ -31,7 +31,7 @@ __optional__|**Example** : `{
 [[_subobject]]
 **SubObject**
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -44,7 +44,7 @@ __optional__|**Example** : `"a value !"`|string
 [[_identified]]
 === Identified
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -55,7 +55,7 @@ __optional__|integer (int64)
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -79,7 +79,7 @@ __optional__|Order Status +
 Test description
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -104,7 +104,7 @@ __optional__|the weight of the pet|number
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -120,7 +120,7 @@ __optional__|string
 __Polymorphism__ : Composition
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +

--- a/src/test/resources/expected/asciidoc/page_breaks/paths.adoc
+++ b/src/test/resources/expected/asciidoc/page_breaks/paths.adoc
@@ -13,7 +13,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -23,7 +23,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -49,7 +49,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -87,7 +87,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -97,7 +97,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -125,7 +125,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -147,7 +147,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -157,7 +157,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -178,7 +178,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -200,7 +200,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -210,7 +210,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|< <<_pet,Pet>> > array
@@ -231,7 +231,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -249,7 +249,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -263,7 +263,7 @@ __required__|Updated status of the pet|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -288,7 +288,7 @@ __required__|Updated status of the pet|string
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -310,7 +310,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -320,7 +320,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_pet,Pet>>
@@ -342,7 +342,7 @@ __required__|ID of the pet|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|
@@ -361,7 +361,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -373,7 +373,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -393,7 +393,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -411,7 +411,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -421,7 +421,7 @@ __optional__|order placed for purchasing the pet|<<_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -489,7 +489,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -499,7 +499,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_order,Order>>
@@ -550,7 +550,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -560,7 +560,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -594,7 +594,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -604,7 +604,7 @@ __optional__|Created user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -633,7 +633,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -643,7 +643,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -672,7 +672,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -682,7 +682,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -711,7 +711,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Query**|**password** +
@@ -723,7 +723,7 @@ __optional__|The user name for login|string|`"testUser"`
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|string
@@ -753,7 +753,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -782,7 +782,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4,.^2"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
 |===
 |Type|Name|Description|Schema|Default
 |**Path**|**username** +
@@ -792,7 +792,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string|`"
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation|<<_user,User>>
@@ -827,7 +827,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -839,7 +839,7 @@ __optional__|Updated user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -873,7 +873,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -883,7 +883,7 @@ __required__|The name that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/page_breaks/security.adoc
+++ b/src/test/resources/expected/asciidoc/page_breaks/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.wordnik.com/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/polymorphism/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphism/definitions.adoc
@@ -11,7 +11,7 @@ __Polymorphism__ : Inheritance
 __Discriminator__ : collType
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**collType** +
@@ -30,7 +30,7 @@ __Polymorphism__ : Inheritance
 __Discriminator__ : petType
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**huntingSkill** +
@@ -48,7 +48,7 @@ __required__||string
 Collection parent type without discriminator
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**name** +
@@ -65,7 +65,7 @@ __Polymorphism__ : Inheritance
 __Discriminator__ : dogType
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**dogType** +
@@ -89,7 +89,7 @@ A map without discriminator
 __Polymorphism__ : Composition
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**collType** +
@@ -104,7 +104,7 @@ __optional__||string
 Pet parent type with discriminator
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**name** +

--- a/src/test/resources/expected/asciidoc/polymorphism/paths.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphism/paths.adoc
@@ -15,7 +15,7 @@ Get collections
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_collection,Collection>>
@@ -45,7 +45,7 @@ Get pets
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_pet,Pet>>

--- a/src/test/resources/expected/asciidoc/polymorphismAsIsOrdering/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphismAsIsOrdering/definitions.adoc
@@ -11,7 +11,7 @@ __Polymorphism__ : Inheritance
 __Discriminator__ : collType
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**name** +
@@ -30,7 +30,7 @@ __Polymorphism__ : Inheritance
 __Discriminator__ : petType
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**name** +
@@ -48,7 +48,7 @@ __required__|The measured skill for hunting +
 Collection parent type without discriminator
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**name** +
@@ -65,7 +65,7 @@ __Polymorphism__ : Inheritance
 __Discriminator__ : dogType
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**name** +
@@ -89,7 +89,7 @@ A map without discriminator
 __Polymorphism__ : Composition
 
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**name** +
@@ -104,7 +104,7 @@ __required__|collection type discriminator|string
 Pet parent type with discriminator
 
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**name** +

--- a/src/test/resources/expected/asciidoc/polymorphismAsIsOrdering/paths.adoc
+++ b/src/test/resources/expected/asciidoc/polymorphismAsIsOrdering/paths.adoc
@@ -15,7 +15,7 @@ Get collections
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_collection,Collection>>
@@ -45,7 +45,7 @@ Get pets
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|OK|<<_pet,Pet>>

--- a/src/test/resources/expected/asciidoc/response_headers/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/response_headers/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -18,7 +18,7 @@ __optional__|string
 [[_pet]]
 === Pet
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -39,7 +39,7 @@ __optional__||< <<_tag,Tag>> > array
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +

--- a/src/test/resources/expected/asciidoc/response_headers/paths.adoc
+++ b/src/test/resources/expected/asciidoc/response_headers/paths.adoc
@@ -15,7 +15,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -25,7 +25,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -59,7 +59,7 @@ This is an important value !. +
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|

--- a/src/test/resources/expected/asciidoc/response_headers/security.adoc
+++ b/src/test/resources/expected/asciidoc/response_headers/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.io/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/to_file/swagger.adoc
+++ b/src/test/resources/expected/asciidoc/to_file/swagger.adoc
@@ -61,7 +61,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -71,7 +71,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -97,7 +97,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -113,7 +113,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -123,7 +123,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -151,7 +151,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -171,7 +171,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -181,7 +181,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -206,7 +206,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -226,7 +226,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -236,7 +236,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -261,7 +261,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -277,7 +277,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -291,7 +291,7 @@ __required__|Updated status of the pet|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -316,7 +316,7 @@ __required__|Updated status of the pet|string
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -336,7 +336,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -346,7 +346,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -372,7 +372,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|
@@ -389,7 +389,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -401,7 +401,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -421,7 +421,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -437,7 +437,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -447,7 +447,7 @@ __optional__|order placed for purchasing the pet|<<_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -483,7 +483,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -493,7 +493,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -530,7 +530,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -540,7 +540,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -572,7 +572,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -582,7 +582,7 @@ __optional__|Created user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -609,7 +609,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -619,7 +619,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -646,7 +646,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -656,7 +656,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -683,7 +683,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**password** +
@@ -695,7 +695,7 @@ __optional__|The user name for login|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -727,7 +727,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -754,7 +754,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -764,7 +764,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -801,7 +801,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -813,7 +813,7 @@ __optional__|Updated user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -845,7 +845,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -855,7 +855,7 @@ __required__|The name that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content
@@ -882,7 +882,7 @@ __required__|The name that needs to be deleted|string
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -899,7 +899,7 @@ __optional__|The name of the category +
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -923,7 +923,7 @@ __optional__|Order Status|enum (Ordered, Cancelled)
 [[_pet]]
 === Pet
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -944,7 +944,7 @@ __optional__||< <<_tag,Tag>> > array
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -957,7 +957,7 @@ __optional__|string
 [[_user]]
 === User
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +
@@ -992,7 +992,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.io/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/to_folder/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/to_folder/definitions.adoc
@@ -5,7 +5,7 @@
 [[_category]]
 === Category
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**id** +
@@ -22,7 +22,7 @@ __optional__|The name of the category +
 [[_order]]
 === Order
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**complete** +
@@ -46,7 +46,7 @@ __optional__|Order Status|enum (Ordered, Cancelled)
 [[_pet]]
 === Pet
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**category** +
@@ -67,7 +67,7 @@ __optional__||< <<_tag,Tag>> > array
 [[_tag]]
 === Tag
 
-[options="header", cols=".^3,.^4"]
+[options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**id** +
@@ -80,7 +80,7 @@ __optional__|string
 [[_user]]
 === User
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**email** +

--- a/src/test/resources/expected/asciidoc/to_folder/paths.adoc
+++ b/src/test/resources/expected/asciidoc/to_folder/paths.adoc
@@ -11,7 +11,7 @@ POST /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -21,7 +21,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -47,7 +47,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -63,7 +63,7 @@ PUT /pets
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -73,7 +73,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -101,7 +101,7 @@ __optional__|Pet object that needs to be added to the store|<<_pet,Pet>>
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -121,7 +121,7 @@ Multiple status values can be provided with comma seperated strings
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**status** +
@@ -131,7 +131,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -156,7 +156,7 @@ __optional__|Status values that need to be considered for filter|< string > arra
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -176,7 +176,7 @@ Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**tags** +
@@ -186,7 +186,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -211,7 +211,7 @@ __optional__|Tags to filter by|< string > array(multi)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -227,7 +227,7 @@ POST /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -241,7 +241,7 @@ __required__|Updated status of the pet|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**405**|Invalid input|No Content
@@ -266,7 +266,7 @@ __required__|Updated status of the pet|string
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -286,7 +286,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
@@ -296,7 +296,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -322,7 +322,7 @@ __required__|ID of pet that needs to be fetched|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**apiKey**|**<<_api_key,api_key>>**|
@@ -339,7 +339,7 @@ DELETE /pets/{petId}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Header**|**api_key** +
@@ -351,7 +351,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid pet value|No Content
@@ -371,7 +371,7 @@ __required__|Pet id to delete|integer (int64)
 
 ==== Security
 
-[options="header", cols=".^3,.^4,.^13"]
+[options="header", cols=".^3a,.^4a,.^13a"]
 |===
 |Type|Name|Scopes
 |**oauth2**|**<<_petstore_auth,petstore_auth>>**|write_pets,read_pets
@@ -387,7 +387,7 @@ POST /stores/order
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -397,7 +397,7 @@ __optional__|order placed for purchasing the pet|<<_order,Order>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -433,7 +433,7 @@ For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values w
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -443,7 +443,7 @@ __required__|ID of pet that needs to be fetched|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -480,7 +480,7 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**orderId** +
@@ -490,7 +490,7 @@ __required__|ID of the order that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid ID supplied|No Content
@@ -522,7 +522,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -532,7 +532,7 @@ __optional__|Created user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -559,7 +559,7 @@ POST /users/createWithArray
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -569,7 +569,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -596,7 +596,7 @@ POST /users/createWithList
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**body** +
@@ -606,7 +606,7 @@ __optional__|List of user object|< <<_user,User>> > array
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -633,7 +633,7 @@ GET /users/login
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Query**|**password** +
@@ -645,7 +645,7 @@ __optional__|The user name for login|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -677,7 +677,7 @@ GET /users/logout
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**default**|successful operation|No Content
@@ -704,7 +704,7 @@ GET /users/{username}
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -714,7 +714,7 @@ __required__|The name that needs to be fetched. Use user1 for testing.|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**200**|successful operation +
@@ -751,7 +751,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -763,7 +763,7 @@ __optional__|Updated user object|<<_user,User>>
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid user supplied|No Content
@@ -795,7 +795,7 @@ This can only be done by the logged in user.
 
 ==== Parameters
 
-[options="header", cols=".^2,.^3,.^9,.^4"]
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**username** +
@@ -805,7 +805,7 @@ __required__|The name that needs to be deleted|string
 
 ==== Responses
 
-[options="header", cols=".^2,.^14,.^4"]
+[options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
 |**400**|Invalid username supplied|No Content

--- a/src/test/resources/expected/asciidoc/to_folder/security.adoc
+++ b/src/test/resources/expected/asciidoc/to_folder/security.adoc
@@ -10,7 +10,7 @@ __Flow__ : implicit
 __Token URL__ : http://petstore.swagger.io/api/oauth/dialog
 
 
-[options="header", cols=".^3,.^17"]
+[options="header", cols=".^3a,.^17a"]
 |===
 |Name|Description
 |write_pets|modify pets in your account

--- a/src/test/resources/expected/asciidoc/validators/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/validators/definitions.adoc
@@ -5,7 +5,7 @@
 [[_samplerequest]]
 === SampleRequest
 
-[options="header", cols=".^3,.^11,.^4"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**sampleDoubleComplete** +

--- a/src/test/resources/yaml/swagger_petstore_with_adoc_content.yaml
+++ b/src/test/resources/yaml/swagger_petstore_with_adoc_content.yaml
@@ -1,0 +1,707 @@
+swagger: "2.0"
+info:
+  description: |
+    This is a sample server Petstore server.
+
+    [Learn about Swagger](http://swagger.io) or join the IRC channel `#swagger` on irc.freenode.net.
+
+    For this sample, you can use the api key `special-key` to test the authorization filters
+  version: "1.0.0"
+  title: Swagger Petstore
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: /v2
+schemes:
+  - http
+tags:
+  - name: pet
+    description: Pet resource
+  - name: store
+    description: Store resource
+  - name: user
+    description: User resource
+paths:
+  /pets:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - $ref: "#/parameters/PetBody"
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - $ref: "#/parameters/PetBody"
+      responses:
+        "405":
+          description: Validation exception
+        "404":
+          description: Pet not found
+        "400":
+          $ref: "#/responses/InvalidId"
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma seperated strings
+      operationId: findPetsByStatus
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: status
+          description: Status values that need to be considered for filter
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Pet"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              type: integer
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: tags
+          description: Tags to filter by
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          x-example: adorable
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Pet"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              type: integer
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/{petId}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
+      operationId: getPetById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be fetched
+          required: true
+          type: integer
+          format: int64
+          x-example: 30
+      responses:
+        "404":
+          description: Pet not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/Pet"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              type: integer
+        "400":
+          $ref: "#/responses/InvalidId"
+      security:
+        - api_key: []
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      consumes:
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be updated
+          required: true
+          type: string
+        - in: formData
+          name: name
+          description: Updated name of the pet
+          required: true
+          type: string
+        - in: formData
+          name: status
+          description: Updated status of the pet
+          required: true
+          type: string
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: header
+          name: api_key
+          description: ""
+          required: true
+          type: string
+        - in: path
+          name: petId
+          description: Pet id to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /stores/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: order placed for purchasing the pet
+          required: false
+          schema:
+            $ref: "#/definitions/Order"
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/Order"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              type: integer
+        "400":
+          description: Invalid Order
+  /stores/order/{orderId}:
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+      operationId: getOrderById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of pet that needs to be fetched
+          required: true
+          type: string
+      responses:
+        "404":
+          description: Order not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/Order"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              type: integer
+        "400":
+          $ref: "#/responses/InvalidId"
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of the order that needs to be deleted
+          required: true
+          type: string
+      responses:
+        "404":
+          description: Order not found
+        "400":
+          $ref: "#/responses/InvalidId"
+  /users:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: Created user object
+          required: false
+          schema:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: List of user object
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: List of user object
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: username
+          description: The user name for login
+          required: false
+          type: string
+        - in: query
+          name: password
+          description: The password for login in clear text
+          required: false
+          type: string
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: string
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              type: integer
+        "400":
+          description: Invalid username/password supplied
+  /users/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        default:
+          description: successful operation
+  /users/{username}:
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          type: string
+      responses:
+        "404":
+          description: User not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/User"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              type: integer
+        "400":
+          description: Invalid username supplied
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: name that need to be deleted
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Updated user object
+          required: false
+          schema:
+            $ref: "#/definitions/User"
+      responses:
+        "404":
+          description: User not found
+        "400":
+          description: Invalid user supplied
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be deleted
+          required: true
+          type: string
+      responses:
+        "404":
+          description: User not found
+        "400":
+          description: Invalid username supplied
+parameters:
+  PetBody:
+    in: body
+    name: body
+    description: Pet object that needs to be added to the store.
+                 You can extend your description with nice asciidoc content like lists
+
+
+                 * Point 1
+
+
+                 * Point 2
+
+
+                 You can even use all formatting options supported by asciidoc(tor)
+
+
+                *bold phrase* & **char**acter**s**
+
+
+                _italic phrase_ & __char__acter__s__
+
+
+                *_bold italic phrase_* & **__char__**acter**__s__**
+
+
+                `monospace phrase` & ``char``acter``s``
+
+
+                `*monospace bold phrase*` & ``**char**``acter``**s**``
+
+
+                `_monospace italic phrase_` & ``__char__``acter``__s__``
+
+
+                `*_monospace bold italic phrase_*` & ``**__char__**``acter``**__s__**``
+    required: false
+    schema:
+      $ref: "#/definitions/Pet"
+responses:
+  InvalidId:
+    description: Invalid ID supplied
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header
+  petstore_auth:
+    type: oauth2
+    authorizationUrl: http://petstore.swagger.io/api/oauth/dialog
+    flow: implicit
+    scopes:
+      write_pets: modify pets in your account
+      read_pets: read your pets
+definitions:
+  User:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      username:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+      phone:
+        type: string
+      userStatus:
+        type: integer
+        format: int32
+        description: User Status
+  Category:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+        description: The name of the category
+        minLength: 0
+        maxLength: 255
+        pattern: "[A-Za-zäöüÄÖÜß]{0,255}"
+        default: DefaultCategory
+        example: FoobarCategory
+  Pet:
+    type: object
+    required:
+      - name
+      - photoUrls
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: "#/definitions/Category"
+      name:
+        type: string
+        example: doggie
+      photoUrls:
+        type: array
+        items:
+          type: string
+      tags:
+        type: array
+        items:
+          $ref: "#/definitions/Tag"
+      status:
+        type: string
+        description: pet status in the store,
+        enum:
+          - Dead
+          - Alive
+  Tag:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+  Order:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      petId:
+        type: integer
+        format: int64
+      quantity:
+        type: integer
+        format: int32
+        minimum: 0
+        maximum: 10000.0
+        default: 0
+        example: 10
+      shipDate:
+        type: string
+        format: date-time
+      status:
+        type: string
+        description: Order Status
+        enum:
+          - Ordered
+          - Cancelled
+      complete:
+        type: boolean
+
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"


### PR DESCRIPTION
* adoc content is possible in tables (by just adding `a` in column spec everywhere
* e.g. in descriptions, need to set ` .withSwaggerMarkupLanguage(MarkupLanguage.ASCIIDOC)` otherwise the `adoc` content is converted to markdown
* updated some plugins and dependecies (e.g. removed javaslang and moved to vavr)
* removed `mavenCentral()` as it should not be required as `jcenter()` contains everything in central (should make dependecy resolution a little faster)
* regarding the deprecation warning for the git pages publish task, I will provide another PR with the required use of the new plugin. [See their description for details](https://github.com/ajoberstar/gradle-git-publish#migrating-from-orgajoberstargithub-pages).

close #162