### PR TITLE
replace deprecated gh pages plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0"
-        classpath "org.ajoberstar:gradle-git:1.7.2"
+        classpath "org.ajoberstar:gradle-git-publish:0.3.1"
     }
 }
 description = 'swagger2markup Build'

--- a/gradle/documentation.gradle
+++ b/gradle/documentation.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'org.asciidoctor.convert'
-apply plugin: 'org.ajoberstar.github-pages'
+apply plugin: 'org.ajoberstar.git-publish'
 
 asciidoctor {
     sources {
@@ -18,17 +18,23 @@ asciidoctor {
     ]
 }
 
-publishGhPages.dependsOn asciidoctor
+gitPublishCommit.dependsOn asciidoctor
 
-githubPages {
-    repoUri = 'https://github.com/Swagger2Markup/swagger2markup.git'
+gitPublish {
+    repoUri = 'git@github.com:Swagger2Markup/swagger2markup.git'
+    branch = 'gh-pages'
 
-    credentials {
-        username = project.hasProperty('githubUser') ? project.githubUser : System.getenv('GITHUB_USER')
-        password = project.hasProperty('githubPassword') ? project.githubPassword : System.getenv('GITHUB_PASSWORD')
-    }
+    // use ENV GRGIT_USER
+    // use ENV GRGIT_PASS
+    // or org.ajoberstar.grgit.auth.username system property
+    // org.ajoberstar.grgit.auth.password system property
+    // see http://ajoberstar.org/grgit/grgit-authentication.html for details
+    // credentials {
+        // username = project.hasProperty('githubUser') ? project.githubUser : System.getenv('GITHUB_USER')
+        // password = project.hasProperty('githubPassword') ? project.githubPassword : System.getenv('GITHUB_PASSWORD')
+    // }
 
-    pages {
+    contents {
         from file(asciidoctor.outputDir.path + '/html5')
         into project.releaseVersion
     }


### PR DESCRIPTION
As promised the deprecated `org.ajoberstar.github-pages` is replaced with `org.ajoberstar.git-publish`.
See https://github.com/ajoberstar/gradle-git-publish#migrating-from-orgajoberstargithub-pages for details.

Most significant change is the authentication it now must be via env or system property. Left a comment in the build file.