### PR TITLE
make examples always start newline if there is other content in the same cell

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/component/PropertiesTableComponent.java
+++ b/src/main/java/io/github/swagger2markup/internal/component/PropertiesTableComponent.java
@@ -186,7 +186,7 @@ public class PropertiesTableComponent extends MarkupComponent<PropertiesTableCom
                 }
 
                 if (optionalExample.isPresent()) {
-                    if (isNotBlank(description) || optionalDefaultValue.isPresent()) {
+                    if (isNotBlank(descriptionContent.toString())) {
                         descriptionContent.newLine(true);
                     }
 


### PR DESCRIPTION
Optional examples will not always start in a new line if there is other content before the example but no optionalDefaultValue. 
For Example: You have an Pattern but no optional default value. Then the example will be in the same line as the pattern and have no white space between the pattern value and the example heading.