### PR TITLE
Resolve issue #298 - Move to latest swagger parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 
 dependencies {
     compile 'io.github.swagger2markup:markup-document-builder:1.1.2'
-    compile 'io.swagger:swagger-compat-spec-parser:1.0.33'
+    compile 'io.swagger:swagger-compat-spec-parser:1.0.34'
     compile 'org.apache.commons:commons-configuration2:2.1'
     compile 'commons-beanutils:commons-beanutils:1.9.2'
     compile 'org.apache.commons:commons-collections4:4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 
 dependencies {
     compile 'io.github.swagger2markup:markup-document-builder:1.1.2'
-    compile 'io.swagger:swagger-compat-spec-parser:1.0.34'
+    compile 'io.swagger:swagger-compat-spec-parser:1.0.35'
     compile 'org.apache.commons:commons-configuration2:2.1'
     compile 'commons-beanutils:commons-beanutils:1.9.2'
     compile 'org.apache.commons:commons-collections4:4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 
 dependencies {
     compile 'io.github.swagger2markup:markup-document-builder:1.1.2'
-    compile 'io.swagger:swagger-compat-spec-parser:1.0.31'
+    compile 'io.swagger:swagger-compat-spec-parser:1.0.33'
     compile 'org.apache.commons:commons-configuration2:2.1'
     compile 'commons-beanutils:commons-beanutils:1.9.2'
     compile 'org.apache.commons:commons-collections4:4.1'

--- a/src/main/java/io/github/swagger2markup/internal/adapter/PropertyAdapter.java
+++ b/src/main/java/io/github/swagger2markup/internal/adapter/PropertyAdapter.java
@@ -139,8 +139,13 @@ public final class PropertyAdapter {
             Property items = arrayProperty.getItems();
             if (items == null)
                 type = new ArrayType(arrayProperty.getTitle(), new ObjectType(null, null)); // FIXME : Workaround for Swagger parser issue with composed models (https://github.com/Swagger2Markup/swagger2markup/issues/150)
-            else
-                type = new ArrayType(arrayProperty.getTitle(), new PropertyAdapter(items).getType(definitionDocumentResolver));
+            else {
+                Type arrayType = new PropertyAdapter(items).getType(definitionDocumentResolver);
+                if (arrayType == null)
+                    type = new ArrayType(arrayProperty.getTitle(), new ObjectType(null, null)); // FIXME : Workaround for Swagger parser issue with composed models (https://github.com/Swagger2Markup/swagger2markup/issues/150)
+                else
+                    type = new ArrayType(arrayProperty.getTitle(), new PropertyAdapter(items).getType(definitionDocumentResolver));
+            }
         } else if (property instanceof MapProperty) {
             MapProperty mapProperty = (MapProperty) property;
             Property additionalProperties = mapProperty.getAdditionalProperties();

--- a/src/main/java/io/github/swagger2markup/internal/adapter/PropertyAdapter.java
+++ b/src/main/java/io/github/swagger2markup/internal/adapter/PropertyAdapter.java
@@ -161,7 +161,9 @@ public final class PropertyAdapter {
         } else if (property instanceof ObjectProperty) {
             type = new ObjectType(property.getTitle(), ((ObjectProperty) property).getProperties());
         } else {
-            if (isNotBlank(property.getFormat())) {
+            if (property.getType() == null) {
+                return null;
+            } else if (isNotBlank(property.getFormat())) {
                 type = new BasicType(property.getType(), property.getTitle(), property.getFormat());
             } else {
                 type = new BasicType(property.getType(), property.getTitle());

--- a/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
@@ -33,6 +33,7 @@ import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
+import io.swagger.models.utils.PropertyModelConverter;
 
 public class ExamplesUtil {
 
@@ -55,19 +56,22 @@ public class ExamplesUtil {
                 Response response = responseEntry.getValue();
                 Object example = response.getExamples();
                 if (example == null) {
-                    Property schema = response.getSchema();
-                    if (schema != null) {
-                        example = schema.getExample();
+                    Model model = response.getResponseSchema();
+                    if (model != null) {
+                        Property schema = new PropertyModelConverter().modelToProperty(model);
+                        if (schema != null) {
+                            example = schema.getExample();
 
-                        if (example == null && schema instanceof RefProperty) {
-                            String simpleRef = ((RefProperty) schema).getSimpleRef();
-                            example = generateExampleForRefModel(generateMissingExamples, simpleRef, definitions, definitionDocumentResolver, markupDocBuilder, new HashMap<>());
-                        }
-                        if (example == null && schema instanceof ArrayProperty && generateMissingExamples) {
-                            example = generateExampleForArrayProperty((ArrayProperty) schema, definitions, definitionDocumentResolver, markupDocBuilder, new HashMap<>());
-                        }
-                        if (example == null && generateMissingExamples) {
-                            example = PropertyAdapter.generateExample(schema, markupDocBuilder);
+                            if (example == null && schema instanceof RefProperty) {
+                                String simpleRef = ((RefProperty) schema).getSimpleRef();
+                                example = generateExampleForRefModel(generateMissingExamples, simpleRef, definitions, definitionDocumentResolver, markupDocBuilder, new HashMap<>());
+                            }
+                            if (example == null && schema instanceof ArrayProperty && generateMissingExamples) {
+                                example = generateExampleForArrayProperty((ArrayProperty) schema, definitions, definitionDocumentResolver, markupDocBuilder, new HashMap<>());
+                            }
+                            if (example == null && generateMissingExamples) {
+                                example = PropertyAdapter.generateExample(schema, markupDocBuilder);
+                            }
                         }
                     }
                 }

--- a/src/main/java/io/github/swagger2markup/internal/utils/ModelUtils.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/ModelUtils.java
@@ -69,7 +69,9 @@ public final class ModelUtils {
                 objectType.getPolymorphism().setDiscriminator(modelImpl.getDiscriminator());
 
                 return objectType;
-            } else if (isNotBlank(modelImpl.getFormat()))
+            } else if (modelImpl.getType() == null)
+                return null;
+            else if (isNotBlank(modelImpl.getFormat()))
                 return new BasicType(modelImpl.getType(), modelImpl.getTitle(), modelImpl.getFormat());
             else
                 return new BasicType(modelImpl.getType(), modelImpl.getTitle());
@@ -84,7 +86,10 @@ public final class ModelUtils {
 
                 for (Model innerModel : composedModel.getAllOf()) {
                     Type innerModelType = resolveRefType(getType(innerModel, definitions, definitionDocumentResolver));
-                    name = innerModelType.getName();
+
+                    if (innerModelType != null) {
+                        name = innerModelType.getName();
+                    }
 
                     if (innerModelType instanceof ObjectType) {
 


### PR DESCRIPTION
By moving from swagger parser version 1.0.31 to 1.0.35, the double quoted text examples identified in issue #298 will be fixed.