### PR TITLE
Generate examples for inline responses - Issue #313

### DIFF
--- a/src/main/java/io/github/swagger2markup/internal/adapter/PropertyAdapter.java
+++ b/src/main/java/io/github/swagger2markup/internal/adapter/PropertyAdapter.java
@@ -50,6 +50,10 @@ public final class PropertyAdapter {
      */
     public static Object generateExample(Property property, MarkupDocBuilder markupDocBuilder) {
 
+        if (property.getType() == null) {
+            return "untyped";
+        }
+
         switch (property.getType()) {
             case "integer":
                 return 0;

--- a/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/ExamplesUtil.java
@@ -29,10 +29,7 @@ import io.github.swagger2markup.markup.builder.MarkupDocBuilder;
 import io.github.swagger2markup.model.PathOperation;
 import io.swagger.models.*;
 import io.swagger.models.parameters.*;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.*;
 import io.swagger.models.utils.PropertyModelConverter;
 
 public class ExamplesUtil {
@@ -68,6 +65,9 @@ public class ExamplesUtil {
                             }
                             if (example == null && schema instanceof ArrayProperty && generateMissingExamples) {
                                 example = generateExampleForArrayProperty((ArrayProperty) schema, definitions, definitionDocumentResolver, markupDocBuilder, new HashMap<>());
+                            }
+                            if (example == null && schema instanceof ObjectProperty && generateMissingExamples) {
+                                example = exampleMapForProperties(((ObjectProperty) schema).getProperties(), definitions, definitionDocumentResolver, markupDocBuilder, new HashMap<>());
                             }
                             if (example == null && generateMissingExamples) {
                                 example = PropertyAdapter.generateExample(schema, markupDocBuilder);

--- a/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
+++ b/src/test/java/io/github/swagger2markup/AsciidocConverterTest.java
@@ -372,6 +372,30 @@ public class AsciidocConverterTest {
     }
 
     @Test
+    public void testWithGeneratedInlineResponseExamples() throws IOException, URISyntaxException {
+        //Given
+        String swaggerJsonString = IOUtils.toString(getClass().getResourceAsStream("/yaml/swagger_examples_inline_response.yaml"));
+        Path outputDirectory = Paths.get("build/test/asciidoc/generated_examples_inline_response");
+        FileUtils.deleteQuietly(outputDirectory.toFile());
+
+        //When
+        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder()
+            .withGeneratedExamples()
+            .build();
+
+        Swagger2MarkupConverter.from(swaggerJsonString)
+            .withConfig(config)
+            .build()
+            .toFolder(outputDirectory);
+
+        //Then
+        String[] files = outputDirectory.toFile().list();
+        assertThat(files).hasSize(4).containsAll(expectedFiles);
+        Path expectedFilesDirectory = Paths.get(AsciidocConverterTest.class.getResource("/expected/asciidoc/generated_examples_inline_response").toURI());
+        DiffUtils.assertThatAllFilesAreEqual(expectedFilesDirectory, outputDirectory, "testWithGeneratedInlineResponseExamples.html");
+    }
+
+    @Test
     public void testWithInlineSchema() throws IOException, URISyntaxException {
         //Given
         Path file = Paths.get(AsciidocConverterTest.class.getResource("/yaml/swagger_inlineSchema.yaml").toURI());

--- a/src/test/resources/expected/asciidoc/generated_examples_inline_response/definitions.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples_inline_response/definitions.adoc
@@ -1,0 +1,18 @@
+
+[[_definitions]]
+== Definitions
+
+[[_category]]
+=== Category
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**id** +
+__optional__|**Example** : `0`|integer (int64)
+|**name** +
+__optional__|**Example** : `"string"`|string
+|===
+
+
+

--- a/src/test/resources/expected/asciidoc/generated_examples_inline_response/overview.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples_inline_response/overview.adoc
@@ -1,0 +1,40 @@
+= Swagger Petstore
+
+
+[[_overview]]
+== Overview
+This is a sample server Petstore server. You can find out more about Swagger at http://swagger.io or on http://swagger.io/irc/["irc.freenode.net, #swagger"]. For this sample, you can use the api key `special-key` to test the authorization filters.
+
+
+=== Version information
+[%hardbreaks]
+__Version__ : 1.0.0
+
+
+=== Contact information
+[%hardbreaks]
+__Contact Email__ : apiteam@swagger.io
+
+
+=== License information
+[%hardbreaks]
+__License__ : Apache 2.0
+__License URL__ : http://www.apache.org/licenses/LICENSE-2.0.html
+__Terms of service__ : http://swagger.io/terms/
+
+
+=== URI scheme
+[%hardbreaks]
+__Host__ : petstore.swagger.io
+__BasePath__ : /v2
+__Schemes__ : HTTP
+
+
+=== Tags
+
+* pet : Everything about your Pets
+* store : Access to Petstore orders
+* user : Operations about user
+
+
+

--- a/src/test/resources/expected/asciidoc/generated_examples_inline_response/paths.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples_inline_response/paths.adoc
@@ -1,0 +1,273 @@
+
+[[_paths]]
+== Paths
+
+[[_pet-inline-object_id_get]]
+=== Finds Pets by id
+....
+GET /pet-inline-object/{id}
+....
+
+
+==== Description
+Locate pets by their unique identifier
+
+
+==== Parameters
+
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|**Query**|**id** +
+__required__|Unique id of the pet|integer
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|successful operation|<<_pet-inline-object_id_get_response_200,Response 200>>
+|**400**|Invalid status value|No Content
+|===
+
+[[_pet-inline-object_id_get_response_200]]
+**Response 200**
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**category** +
+__optional__|**Example** : <<_category>>|<<_category,Category>>
+|**id** +
+__required__|**Example** : `3`|integer (int64)
+|**name** +
+__required__|**Example** : `"doggie"`|string
+|**status** +
+__optional__|pet status in the store +
+**Example** : `"string"`|enum (available, pending, sold)
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
+==== Tags
+
+* pet
+
+
+==== Security
+
+[options="header", cols=".^3a,.^4a,.^13a"]
+|===
+|Type|Name|Scopes
+|**oauth2**|**<<_petstore_auth,petstore_auth>>**|write:pets,read:pets
+|===
+
+
+==== Example HTTP request
+
+===== Request path
+----
+/pet-inline-object/{id}?id=3
+----
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "id" : 3,
+  "category" : {
+    "id" : 0,
+    "name" : "string"
+  },
+  "name" : "doggie",
+  "status" : "string"
+}
+----
+
+
+[[_pet-inline-titled-object_id_get]]
+=== Finds Pets by id
+....
+GET /pet-inline-titled-object/{id}
+....
+
+
+==== Description
+Locate pets by their unique identifier
+
+
+==== Parameters
+
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|**Query**|**id** +
+__required__|Unique id of the pet|integer
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|successful operation|<<_pet,pet>>
+|**400**|Invalid status value|No Content
+|===
+
+[[_pet]]
+**pet**
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**category** +
+__optional__|**Example** : <<_category>>|<<_category,Category>>
+|**id** +
+__required__|**Example** : `3`|integer (int64)
+|**name** +
+__required__|**Example** : `"doggie"`|string
+|**status** +
+__optional__|pet status in the store +
+**Example** : `"string"`|enum (available, pending, sold)
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
+==== Tags
+
+* pet
+
+
+==== Security
+
+[options="header", cols=".^3a,.^4a,.^13a"]
+|===
+|Type|Name|Scopes
+|**oauth2**|**<<_petstore_auth,petstore_auth>>**|write:pets,read:pets
+|===
+
+
+==== Example HTTP request
+
+===== Request path
+----
+/pet-inline-titled-object/{id}?id=3
+----
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "id" : 3,
+  "category" : {
+    "id" : 0,
+    "name" : "string"
+  },
+  "name" : "doggie",
+  "status" : "string"
+}
+----
+
+
+[[_pet-inline-untyped_id_get]]
+=== Finds Pets by id
+....
+GET /pet-inline-untyped/{id}
+....
+
+
+==== Description
+Locate pets by their unique identifier
+
+
+==== Parameters
+
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|**Query**|**id** +
+__required__|Unique id of the pet|integer
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|successful operation|<<_pet-inline-untyped_id_get_response_200,Response 200>>
+|**400**|Invalid status value|No Content
+|===
+
+[[_pet-inline-untyped_id_get_response_200]]
+**Response 200**
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**category** +
+__optional__|**Example** : <<_category>>|<<_category,Category>>
+|**id** +
+__required__|**Example** : `3`|integer (int64)
+|**name** +
+__required__|**Example** : `"doggie"`|string
+|**status** +
+__optional__|pet status in the store +
+**Example** : `"string"`|enum (available, pending, sold)
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
+==== Tags
+
+* pet
+
+
+==== Security
+
+[options="header", cols=".^3a,.^4a,.^13a"]
+|===
+|Type|Name|Scopes
+|**oauth2**|**<<_petstore_auth,petstore_auth>>**|write:pets,read:pets
+|===
+
+
+==== Example HTTP request
+
+===== Request path
+----
+/pet-inline-untyped/{id}?id=3
+----
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+"untyped"
+----
+
+
+

--- a/src/test/resources/expected/asciidoc/generated_examples_inline_response/security.adoc
+++ b/src/test/resources/expected/asciidoc/generated_examples_inline_response/security.adoc
@@ -1,0 +1,29 @@
+
+[[_securityscheme]]
+== Security
+
+[[_petstore_auth]]
+=== petstore_auth
+[%hardbreaks]
+__Type__ : oauth2
+__Flow__ : implicit
+__Token URL__ : http://petstore.swagger.io/oauth/dialog
+
+
+[options="header", cols=".^3a,.^17a"]
+|===
+|Name|Description
+|write:pets|modify pets in your account
+|read:pets|read your pets
+|===
+
+
+[[_api_key]]
+=== api_key
+[%hardbreaks]
+__Type__ : apiKey
+__Name__ : api_key
+__In__ : HEADER
+
+
+

--- a/src/test/resources/yaml/swagger_examples_inline_response.yaml
+++ b/src/test/resources/yaml/swagger_examples_inline_response.yaml
@@ -1,0 +1,191 @@
+swagger: "2.0"
+info:
+  description: "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters."
+  version: "1.0.0"
+  title: "Swagger Petstore"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "petstore.swagger.io"
+basePath: "/v2"
+tags:
+- name: "pet"
+  description: "Everything about your Pets"
+  externalDocs:
+    description: "Find out more"
+    url: "http://swagger.io"
+- name: "store"
+  description: "Access to Petstore orders"
+- name: "user"
+  description: "Operations about user"
+  externalDocs:
+    description: "Find out more about our store"
+    url: "http://swagger.io"
+schemes:
+- "http"
+paths:
+
+  /pet-inline-untyped/{id}:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by id"
+      description: "Locate pets by their unique identifier"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "query"
+        description: "Unique id of the pet"
+        required: true
+        type: "integer"
+        x-example: 3
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            required:
+            - "id"
+            - "name"
+            properties:
+              id:
+                type: "integer"
+                format: "int64"
+                example: 3
+              category:
+                $ref: "#/definitions/Category"
+              name:
+                type: "string"
+                example: "doggie"
+              status:
+                type: "string"
+                description: "pet status in the store"
+                enum:
+                - "available"
+                - "pending"
+                - "sold"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet-inline-object/{id}:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by id"
+      description: "Locate pets by their unique identifier"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "query"
+        description: "Unique id of the pet"
+        required: true
+        type: "integer"
+        x-example: 3
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            required:
+            - "id"
+            - "name"
+            properties:
+              id:
+                type: "integer"
+                format: "int64"
+                example: 3
+              category:
+                $ref: "#/definitions/Category"
+              name:
+                type: "string"
+                example: "doggie"
+              status:
+                type: "string"
+                description: "pet status in the store"
+                enum:
+                - "available"
+                - "pending"
+                - "sold"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet-inline-titled-object/{id}:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by id"
+      description: "Locate pets by their unique identifier"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "query"
+        description: "Unique id of the pet"
+        required: true
+        type: "integer"
+        x-example: 3
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            title: "pet"
+            required:
+            - "id"
+            - "name"
+            properties:
+              id:
+                type: "integer"
+                format: "int64"
+                example: 3
+              category:
+                $ref: "#/definitions/Category"
+              name:
+                type: "string"
+                example: "doggie"
+              status:
+                type: "string"
+                description: "pet status in the store"
+                enum:
+                - "available"
+                - "pending"
+                - "sold"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+
+securityDefinitions:
+  petstore_auth:
+    type: "oauth2"
+    authorizationUrl: "http://petstore.swagger.io/oauth/dialog"
+    flow: "implicit"
+    scopes:
+      write:pets: "modify pets in your account"
+      read:pets: "read your pets"
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+
+definitions:
+  Category:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"


### PR DESCRIPTION
* Handle untyped inlines - swagger parser no longer defaults untyped to object types
* Handle object inlines - generates a name based on method and response code
* Handle object inlines with titles - generates a name from the title