### PR TITLE
add hostname in uri section of every operation, it is configurable.

### DIFF
--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
@@ -45,6 +45,9 @@ public interface Swagger2MarkupConfig {
      */
     boolean isGeneratedExamplesEnabled();
 
+    /**
+     * Prepend the hostname to all paths.
+     */
     boolean isHostnameEnabled();
     /**
      * Prepend the base path to all paths.

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupConfig.java
@@ -45,6 +45,7 @@ public interface Swagger2MarkupConfig {
      */
     boolean isGeneratedExamplesEnabled();
 
+    boolean isHostnameEnabled();
     /**
      * Prepend the base path to all paths.
      */

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupProperties.java
@@ -40,6 +40,7 @@ public class Swagger2MarkupProperties {
     public static final String MARKUP_LANGUAGE = PROPERTIES_PREFIX + ".markupLanguage";
     public static final String SWAGGER_MARKUP_LANGUAGE = PROPERTIES_PREFIX + ".swaggerMarkupLanguage";
     public static final String GENERATED_EXAMPLES_ENABLED = PROPERTIES_PREFIX + ".generatedExamplesEnabled";
+    public static final String HOSTNAME_ENABLED = PROPERTIES_PREFIX + ".hostnameEnabled";
     public static final String BASE_PATH_PREFIX_ENABLED = PROPERTIES_PREFIX + ".basePathPrefixEnabled";
     public static final String SEPARATED_DEFINITIONS_ENABLED = PROPERTIES_PREFIX + ".separatedDefinitionsEnabled";
     public static final String SEPARATED_OPERATIONS_ENABLED = PROPERTIES_PREFIX + ".separatedOperationsEnabled";

--- a/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
+++ b/src/main/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilder.java
@@ -85,6 +85,7 @@ public class Swagger2MarkupConfigBuilder {
         config.markupLanguage = swagger2MarkupProperties.getRequiredMarkupLanguage(MARKUP_LANGUAGE);
         config.swaggerMarkupLanguage = swagger2MarkupProperties.getRequiredMarkupLanguage(SWAGGER_MARKUP_LANGUAGE);
         config.generatedExamplesEnabled = swagger2MarkupProperties.getRequiredBoolean(GENERATED_EXAMPLES_ENABLED);
+        config.hostnameEnabled = swagger2MarkupProperties.getRequiredBoolean(HOSTNAME_ENABLED);
         config.basePathPrefixEnabled = swagger2MarkupProperties.getRequiredBoolean(BASE_PATH_PREFIX_ENABLED);
         config.separatedDefinitionsEnabled = swagger2MarkupProperties.getRequiredBoolean(SEPARATED_DEFINITIONS_ENABLED);
         config.separatedOperationsEnabled = swagger2MarkupProperties.getRequiredBoolean(SEPARATED_OPERATIONS_ENABLED);
@@ -555,6 +556,7 @@ public class Swagger2MarkupConfigBuilder {
         private MarkupLanguage markupLanguage;
         private MarkupLanguage swaggerMarkupLanguage;
         private boolean generatedExamplesEnabled;
+        private boolean hostnameEnabled;
         private boolean basePathPrefixEnabled;
         private boolean separatedDefinitionsEnabled;
         private boolean separatedOperationsEnabled;
@@ -774,6 +776,11 @@ public class Swagger2MarkupConfigBuilder {
         @Override
         public Swagger2MarkupProperties getExtensionsProperties() {
             return extensionsProperties;
+        }
+
+        @Override
+        public boolean isHostnameEnabled() {
+            return hostnameEnabled;
         }
 
         @Override

--- a/src/main/java/io/github/swagger2markup/internal/document/PathsDocument.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/PathsDocument.java
@@ -113,7 +113,7 @@ public class PathsDocument extends MarkupComponent<PathsDocument.Parameters> {
      * @param paths the Swagger paths
      */
     private void buildsPathsSection(MarkupDocBuilder markupDocBuilder, Map<String, Path> paths) {
-        List<PathOperation> pathOperations = PathUtils.toPathOperationsList(paths, getBasePath(), config.getOperationOrdering());
+        List<PathOperation> pathOperations = PathUtils.toPathOperationsList(paths, getHostname(), getBasePath(), config.getOperationOrdering());
         if (CollectionUtils.isNotEmpty(pathOperations)) {
             if (config.getPathsGroupedBy() == GroupBy.AS_IS) {
                 pathOperations.forEach(operation -> buildOperation(markupDocBuilder, operation, config));
@@ -160,6 +160,18 @@ public class PathsDocument extends MarkupComponent<PathsDocument.Parameters> {
         } else {
             buildPathsTitle(markupDocBuilder, labels.getLabel(Labels.RESOURCES));
         }
+    }
+
+    /**
+     * Returns the basePath which should be prepended to the relative path
+     *
+     * @return either the relative or the full path
+     */
+    private String getHostname() {
+        if (config.isHostnameEnabled()) {
+            return StringUtils.defaultString(context.getSwagger().getHost());
+        }
+        return "";
     }
 
     /**

--- a/src/main/java/io/github/swagger2markup/internal/document/PathsDocument.java
+++ b/src/main/java/io/github/swagger2markup/internal/document/PathsDocument.java
@@ -163,7 +163,7 @@ public class PathsDocument extends MarkupComponent<PathsDocument.Parameters> {
     }
 
     /**
-     * Returns the basePath which should be prepended to the relative path
+     * Returns the hostname which should be prepended to the relative path
      *
      * @return either the relative or the full path
      */

--- a/src/main/java/io/github/swagger2markup/internal/utils/PathUtils.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/PathUtils.java
@@ -67,12 +67,13 @@ public class PathUtils {
      * @return the path operations
      */
     public static List<PathOperation> toPathOperationsList(Map<String, Path> paths,
+                                                           String host,
                                                            String basePath,
                                                            Comparator<PathOperation> comparator) {
         List<PathOperation> pathOperations = new ArrayList<>();
 
         paths.forEach((relativePath, path) ->
-                pathOperations.addAll(toPathOperationsList(basePath + relativePath, path)));
+                pathOperations.addAll(toPathOperationsList(host + basePath + relativePath, path)));
         if (comparator != null) {
             pathOperations.sort(comparator);
         }

--- a/src/main/java/io/github/swagger2markup/internal/utils/PathUtils.java
+++ b/src/main/java/io/github/swagger2markup/internal/utils/PathUtils.java
@@ -62,6 +62,7 @@ public class PathUtils {
      * Converts the Swagger paths into a list of PathOperations.
      *
      * @param paths      the Swagger paths
+     * @param host       the host of all paths
      * @param basePath   the basePath of all paths
      * @param comparator the comparator to use.
      * @return the path operations

--- a/src/main/resources/io/github/swagger2markup/config/default.properties
+++ b/src/main/resources/io/github/swagger2markup/config/default.properties
@@ -1,6 +1,7 @@
 swagger2markup.markupLanguage=ASCIIDOC
 swagger2markup.swaggerMarkupLanguage=MARKDOWN
 swagger2markup.generatedExamplesEnabled=false
+swagger2markup.hostnameEnabled=false
 swagger2markup.basePathPrefixEnabled=false
 swagger2markup.operationExtensionsEnabled=false
 swagger2markup.definitionExtensionsEnabled=false

--- a/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
+++ b/src/test/java/io/github/swagger2markup/builder/Swagger2MarkupConfigBuilderTest.java
@@ -97,6 +97,7 @@ public class Swagger2MarkupConfigBuilderTest {
         assertThat(config.getDefinitionOrdering()).isNull();
         assertThat(config.getDefinitionsDocument()).isEqualTo("definitionsTest");
         assertThat(config.isGeneratedExamplesEnabled()).isTrue();
+        assertThat(config.isHostnameEnabled()).isEqualTo(false);
         assertThat(config.isInlineSchemaEnabled()).isEqualTo(false);
         assertThat(config.getInterDocumentCrossReferencesPrefix()).isEqualTo("xrefPrefix");
         assertThat(config.getMarkupLanguage()).isEqualTo(MarkupLanguage.MARKDOWN);

--- a/src/test/java/io/github/swagger2markup/internal/component/SecuritySchemeComponentTest.java
+++ b/src/test/java/io/github/swagger2markup/internal/component/SecuritySchemeComponentTest.java
@@ -51,7 +51,7 @@ public class SecuritySchemeComponentTest extends AbstractComponentTest {
         Swagger2MarkupConverter converter = Swagger2MarkupConverter.from(file).build();
         Swagger swagger = converter.getContext().getSwagger();
 
-        List<PathOperation> pathOperations = PathUtils.toPathOperationsList(swagger.getPaths(), "",
+        List<PathOperation> pathOperations = PathUtils.toPathOperationsList(swagger.getPaths(), "", "",
                 converter.getContext().getConfig().getOperationOrdering());
 
         Swagger2MarkupConverter.Context context = converter.getContext();


### PR DESCRIPTION
Sometimes, we need to merge the api docs of several services into one, which requires the full path of each api, including the hostname. I found that this feature is not currently supported, so this pr exists.

In order to get a complete api path, you need to do the following:
1.modify swagger configuration
	new Docket().host("your own hostname")
2. add swagger2markup configuration, the default value is false
	swagger2markup.hostnameEnabled=true

Thanks for spending time reviewing this pr, looking forward to feedback.