### PR TITLE
OpenApi 3.0 example object support

### DIFF
--- a/swagger2markup-asciidoc/src/main/java/io/github/swagger2markup/adoc/AsciidocConverter.java
+++ b/swagger2markup-asciidoc/src/main/java/io/github/swagger2markup/adoc/AsciidocConverter.java
@@ -777,6 +777,7 @@ public class AsciidocConverter extends StringConverter {
     private String convertParagraph(StructuralNode node) {
         logger.debug("convertParagraph");
         StringBuilder sb = new StringBuilder();
+        appendTitle(node, sb);
         sb.append(new ParagraphAttributes(node).toAsciiDocContent());
         appendSource((Block) node, sb);
         appendTrailingNewLine(sb);

--- a/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/EncodingComponent.java
+++ b/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/EncodingComponent.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Robert Winkler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.swagger2markup.internal.component;
+
+import io.github.swagger2markup.OpenAPI2MarkupConverter;
+import io.github.swagger2markup.adoc.ast.impl.DescriptionListEntryImpl;
+import io.github.swagger2markup.adoc.ast.impl.DescriptionListImpl;
+import io.github.swagger2markup.adoc.ast.impl.ListItemImpl;
+import io.github.swagger2markup.adoc.ast.impl.ParagraphBlockImpl;
+import io.github.swagger2markup.extension.MarkupComponent;
+import io.swagger.v3.oas.models.media.Encoding;
+import org.apache.commons.lang3.StringUtils;
+import org.asciidoctor.ast.StructuralNode;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static io.github.swagger2markup.adoc.converter.internal.Delimiters.LINE_SEPARATOR;
+import static io.github.swagger2markup.internal.helper.OpenApiHelpers.LABEL_EXAMPLES;
+import static io.github.swagger2markup.internal.helper.OpenApiHelpers.italicUnconstrained;
+
+public class EncodingComponent extends MarkupComponent<StructuralNode, EncodingComponent.Parameters, StructuralNode> {
+
+    private final HeadersComponent headersComponent;
+
+    public EncodingComponent(OpenAPI2MarkupConverter.OpenAPIContext context) {
+        super(context);
+        this.headersComponent = new HeadersComponent(context);
+    }
+
+    public static EncodingComponent.Parameters parameters(Map<String, Encoding> encodings) {
+        return new EncodingComponent.Parameters(encodings);
+    }
+
+    public StructuralNode apply(StructuralNode node, Map<String, Encoding> encodings) {
+        return apply(node, parameters(encodings));
+    }
+
+    @Override
+    public StructuralNode apply(StructuralNode node, EncodingComponent.Parameters parameters) {
+        Map<String, Encoding> encodings = parameters.encodings;
+        if (encodings == null || encodings.isEmpty()) return node;
+
+        DescriptionListImpl encodingList = new DescriptionListImpl(node);
+        encodingList.setTitle(LABEL_EXAMPLES);
+
+        encodings.forEach((name, encoding) -> {
+            DescriptionListEntryImpl encodingEntry = new DescriptionListEntryImpl(encodingList, Collections.singletonList(new ListItemImpl(encodingList, name)));
+            ListItemImpl tagDesc = new ListItemImpl(encodingEntry, "");
+            ParagraphBlockImpl encodingBlock = new ParagraphBlockImpl(tagDesc);
+
+            StringBuilder sb = new StringBuilder();
+            String contentType = encoding.getContentType();
+            if(StringUtils.isNotBlank(contentType)){
+                sb.append("Content-Type:").append(contentType).append(LINE_SEPARATOR);
+            }
+            if(encoding.getAllowReserved()){
+                sb.append(italicUnconstrained("Allow Reserved").toLowerCase()).append(LINE_SEPARATOR);
+            }
+            if(encoding.getExplode()){
+                sb.append(italicUnconstrained("Explode").toLowerCase()).append(LINE_SEPARATOR);
+            }
+            Encoding.StyleEnum style = encoding.getStyle();
+            if(style != null){
+                sb.append("style").append(style).append(LINE_SEPARATOR);
+            }
+            encodingBlock.setSource(sb.toString());
+            tagDesc.append(encodingBlock);
+            headersComponent.apply(tagDesc, encoding.getHeaders());
+
+            encodingEntry.setDescription(tagDesc);
+
+            encodingList.addEntry(encodingEntry);
+        });
+        node.append(encodingList);
+
+        return node;
+    }
+
+    public static class Parameters {
+
+        private final Map<String, Encoding> encodings;
+
+        public Parameters(Map<String, Encoding> encodings) {
+            this.encodings = encodings;
+        }
+    }
+}

--- a/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/ExamplesComponent.java
+++ b/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/ExamplesComponent.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 Robert Winkler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.swagger2markup.internal.component;
+
+import io.github.swagger2markup.OpenAPI2MarkupConverter;
+import io.github.swagger2markup.adoc.ast.impl.DescriptionListEntryImpl;
+import io.github.swagger2markup.adoc.ast.impl.DescriptionListImpl;
+import io.github.swagger2markup.adoc.ast.impl.ListItemImpl;
+import io.github.swagger2markup.adoc.ast.impl.ParagraphBlockImpl;
+import io.github.swagger2markup.extension.MarkupComponent;
+import io.swagger.v3.oas.models.examples.Example;
+import org.apache.commons.lang3.StringUtils;
+import org.asciidoctor.ast.StructuralNode;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static io.github.swagger2markup.adoc.converter.internal.Delimiters.LINE_SEPARATOR;
+import static io.github.swagger2markup.internal.helper.OpenApiHelpers.*;
+
+public class ExamplesComponent extends MarkupComponent<StructuralNode, ExamplesComponent.Parameters, StructuralNode> {
+
+    private final MediaTypeExampleComponent mediaTypeExampleComponent;
+
+    public ExamplesComponent(OpenAPI2MarkupConverter.OpenAPIContext context) {
+        super(context);
+        this.mediaTypeExampleComponent = new MediaTypeExampleComponent(context);
+    }
+
+    public static ExamplesComponent.Parameters parameters(Map<String, Example> examples) {
+        return new ExamplesComponent.Parameters(examples);
+    }
+
+    public StructuralNode apply(StructuralNode node, Map<String, Example> examples) {
+        return apply(node, parameters(examples));
+    }
+
+    @Override
+    public StructuralNode apply(StructuralNode node, ExamplesComponent.Parameters parameters) {
+        Map<String, Example> examples = parameters.examples;
+        if (examples == null || examples.isEmpty()) return node;
+
+        DescriptionListImpl examplesList = new DescriptionListImpl(node);
+        examplesList.setTitle(LABEL_EXAMPLES);
+
+        examples.forEach((name, example) -> {
+            DescriptionListEntryImpl exampleEntry = new DescriptionListEntryImpl(examplesList, Collections.singletonList(new ListItemImpl(examplesList, name)));
+            ListItemImpl tagDesc = new ListItemImpl(exampleEntry, "");
+
+            ParagraphBlockImpl exampleBlock = new ParagraphBlockImpl(tagDesc);
+
+            appendDescription(exampleBlock, example.getSummary());
+            appendDescription(exampleBlock, example.getDescription());
+            mediaTypeExampleComponent.apply(tagDesc, example.getValue());
+
+            ParagraphBlockImpl paragraphBlock = new ParagraphBlockImpl(tagDesc);
+            String source = "";
+            generateRefLink(source, example.getExternalValue(), LABEL_EXTERNAL_VALUE);
+            generateRefLink(source, example.get$ref(), "");
+            if(StringUtils.isNotBlank(source)){
+                paragraphBlock.setSource(source);
+                tagDesc.append(paragraphBlock);
+            }
+
+            exampleEntry.setDescription(tagDesc);
+
+            examplesList.addEntry(exampleEntry);
+        });
+        node.append(examplesList);
+
+        return node;
+    }
+
+    private String generateRefLink(String source, String ref, String alt) {
+        if (StringUtils.isNotBlank(ref)) {
+            if (StringUtils.isBlank(alt)) {
+                alt = ref.substring(ref.lastIndexOf('/') + 1);
+            }
+            String anchor = ref.replaceFirst("#", "").replaceAll("/", "_");
+            source += "<<" + anchor + "," + alt + ">>" + LINE_SEPARATOR;
+        }
+        return source;
+    }
+
+
+    public static class Parameters {
+
+        private final Map<String, Example> examples;
+
+        public Parameters(Map<String, Example> examples) {
+            this.examples = examples;
+        }
+    }
+}

--- a/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/MediaContentComponent.java
+++ b/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/MediaContentComponent.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Robert Winkler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.swagger2markup.internal.component;
+
+import io.github.swagger2markup.OpenAPI2MarkupConverter;
+import io.github.swagger2markup.adoc.ast.impl.DescriptionListEntryImpl;
+import io.github.swagger2markup.adoc.ast.impl.DescriptionListImpl;
+import io.github.swagger2markup.adoc.ast.impl.ListItemImpl;
+import io.github.swagger2markup.extension.MarkupComponent;
+import io.swagger.v3.oas.models.media.Content;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
+
+import java.util.Collections;
+
+import static io.github.swagger2markup.internal.helper.OpenApiHelpers.*;
+
+public class MediaContentComponent extends MarkupComponent<StructuralNode, MediaContentComponent.Parameters, StructuralNode> {
+
+    private final MediaTypeExampleComponent mediaTypeExampleComponent;
+    private final ExamplesComponent examplesComponent;
+    private final SchemaComponent schemaComponent;
+    private final EncodingComponent encodingComponent;
+
+    public MediaContentComponent(OpenAPI2MarkupConverter.OpenAPIContext context) {
+        super(context);
+        this.mediaTypeExampleComponent = new MediaTypeExampleComponent(context);
+        this.examplesComponent = new ExamplesComponent(context);
+        this.schemaComponent = new SchemaComponent(context);
+        this.encodingComponent = new EncodingComponent(context);
+    }
+
+    public static MediaContentComponent.Parameters parameters(Content content) {
+        return new MediaContentComponent.Parameters(content);
+    }
+
+    public StructuralNode apply(StructuralNode node, Content content) {
+        return apply(node, parameters(content));
+    }
+
+    @Override
+    public StructuralNode apply(StructuralNode node, MediaContentComponent.Parameters parameters) {
+        Content content = parameters.content;
+        if (content == null || content.isEmpty()) return node;
+
+        DescriptionListImpl mediaContentList = new DescriptionListImpl(node);
+        mediaContentList.setTitle(LABEL_CONTENT);
+
+        content.forEach((type, mediaType) -> {
+            DescriptionListEntryImpl tagEntry = new DescriptionListEntryImpl(mediaContentList, Collections.singletonList(new ListItemImpl(mediaContentList, type)));
+            ListItemImpl tagDesc = new ListItemImpl(tagEntry, "");
+
+            Document tagDescDocument = schemaComponent.apply(mediaContentList, mediaType.getSchema());
+            mediaTypeExampleComponent.apply(tagDescDocument, mediaType.getExample());
+            examplesComponent.apply(tagDescDocument, mediaType.getExamples());
+            encodingComponent.apply(tagDescDocument, mediaType.getEncoding());
+            tagDesc.append(tagDescDocument);
+
+            tagEntry.setDescription(tagDesc);
+            mediaContentList.addEntry(tagEntry);
+        });
+        node.append(mediaContentList);
+        return node;
+    }
+
+    public static class Parameters {
+
+        private final Content content;
+
+        public Parameters(Content content) {
+            this.content = content;
+        }
+    }
+}

--- a/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/MediaTypeExampleComponent.java
+++ b/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/MediaTypeExampleComponent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Robert Winkler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.swagger2markup.internal.component;
+
+import io.github.swagger2markup.OpenAPI2MarkupConverter;
+import io.github.swagger2markup.adoc.ast.impl.ParagraphBlockImpl;
+import io.github.swagger2markup.extension.MarkupComponent;
+import org.apache.commons.lang3.StringUtils;
+import org.asciidoctor.ast.StructuralNode;
+
+import static io.github.swagger2markup.adoc.converter.internal.Delimiters.DELIMITER_BLOCK;
+import static io.github.swagger2markup.adoc.converter.internal.Delimiters.LINE_SEPARATOR;
+import static io.github.swagger2markup.internal.helper.OpenApiHelpers.LABEL_EXAMPLE;
+
+public class MediaTypeExampleComponent extends MarkupComponent<StructuralNode, MediaTypeExampleComponent.Parameters, StructuralNode> {
+
+    public MediaTypeExampleComponent(OpenAPI2MarkupConverter.OpenAPIContext context) {
+        super(context);
+    }
+
+    public static MediaTypeExampleComponent.Parameters parameters(Object example) {
+        return new MediaTypeExampleComponent.Parameters(example);
+    }
+
+    public StructuralNode apply(StructuralNode node, Object example) {
+        return apply(node, parameters(example));
+    }
+
+    @Override
+    public StructuralNode apply(StructuralNode node, MediaTypeExampleComponent.Parameters parameters) {
+        Object example = parameters.example;
+        if (example == null || StringUtils.isBlank(example.toString())) return node;
+
+        ParagraphBlockImpl sourceBlock = new ParagraphBlockImpl(node);
+        sourceBlock.setTitle(LABEL_EXAMPLE);
+        sourceBlock.setAttribute("style", "source", true);
+        sourceBlock.setSource(DELIMITER_BLOCK + LINE_SEPARATOR + example + LINE_SEPARATOR + DELIMITER_BLOCK);
+        node.append(sourceBlock);
+
+        return node;
+    }
+
+    public static class Parameters {
+
+        private final Object example;
+
+        public Parameters(Object example) {
+            this.example = example;
+        }
+    }
+}

--- a/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/ResponseComponent.java
+++ b/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/ResponseComponent.java
@@ -33,11 +33,13 @@ public class ResponseComponent extends MarkupComponent<StructuralNode, ResponseC
 
     private final HeadersComponent headersComponent;
     private final LinkComponent linkComponent;
+    private final MediaContentComponent mediaContentComponent;
 
     public ResponseComponent(OpenAPI2MarkupConverter.OpenAPIContext context) {
         super(context);
         this.headersComponent = new HeadersComponent(context);
         this.linkComponent = new LinkComponent(context);
+        this.mediaContentComponent = new MediaContentComponent(context);
     }
 
     public static Parameters parameters(Map<String, ApiResponse> apiResponses) {
@@ -74,6 +76,7 @@ public class ResponseComponent extends MarkupComponent<StructuralNode, ResponseC
     private Document getResponseDescriptionColumnDocument(Table table, ApiResponse apiResponse) {
         Document document = OpenApiHelpers.generateInnerDoc(table, Optional.ofNullable(apiResponse.getDescription()).orElse(""));
         headersComponent.apply(document, apiResponse.getHeaders());
+        mediaContentComponent.apply(document, apiResponse.getContent());
         return document;
     }
 

--- a/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/SchemaComponent.java
+++ b/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/component/SchemaComponent.java
@@ -93,12 +93,7 @@ public class SchemaComponent extends MarkupComponent<StructuralNode, SchemaCompo
 
         ParagraphBlockImpl paragraphBlock = new ParagraphBlockImpl(schemaDocument);
         String source = Stream.concat(schemaBooleanStream, schemaValueStream).collect(Collectors.joining(" +" + LINE_SEPARATOR));
-        String ref = schema.get$ref();
-        if (StringUtils.isNotBlank(ref)) {
-            String alt = ref.substring(ref.lastIndexOf('/') + 1);
-            String anchor = ref.replaceFirst("#", "").replaceAll("/", "_");
-            source += "<<" + anchor + "," + alt + ">>" + LINE_SEPARATOR;
-        }
+        source = generateRefLink(source, schema.get$ref());
         paragraphBlock.setSource(source);
 
         schemaDocument.append(paragraphBlock);
@@ -110,6 +105,14 @@ public class SchemaComponent extends MarkupComponent<StructuralNode, SchemaCompo
         }
 
         return schemaDocument;
+    }
+
+    private String generateRefLink(String source, String ref) {
+        if (StringUtils.isNotBlank(ref)) {
+            String anchor = ref.replaceFirst("#", "").replaceAll("/", "_");
+            source += "<<" + anchor + ">>" + LINE_SEPARATOR;
+        }
+        return source;
     }
 
     @SuppressWarnings("rawtypes")

--- a/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/helper/OpenApiHelpers.java
+++ b/swagger2markup-swagger-v3/src/main/java/io/github/swagger2markup/internal/helper/OpenApiHelpers.java
@@ -2,6 +2,7 @@ package io.github.swagger2markup.internal.helper;
 
 import io.github.swagger2markup.adoc.ast.impl.DocumentImpl;
 import io.github.swagger2markup.adoc.ast.impl.ParagraphBlockImpl;
+import io.swagger.v3.oas.models.ExternalDocumentation;
 import org.apache.commons.lang3.StringUtils;
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.Document;
@@ -10,10 +11,14 @@ import org.asciidoctor.ast.Table;
 
 public class OpenApiHelpers {
 
+    public static final String LABEL_CONTENT = "Content";
     public static final String LABEL_DEFAULT = "Default";
     public static final String LABEL_DEPRECATED = "Deprecated";
+    public static final String LABEL_EXAMPLE = "Example";
+    public static final String LABEL_EXAMPLES = "Examples";
     public static final String LABEL_EXCLUSIVE_MAXIMUM = "Exclusive Maximum";
     public static final String LABEL_EXCLUSIVE_MINIMUM = "Exclusive Minimum";
+    public static final String LABEL_EXTERNAL_VALUE = "External Value";
     public static final String LABEL_FORMAT = "Format";
     public static final String LABEL_MAXIMUM = "Maximum";
     public static final String LABEL_MAX_ITEMS = "Maximum Items";
@@ -85,6 +90,18 @@ public class OpenApiHelpers {
 
     public static String requiredIndicator(boolean isRequired) {
         return italicUnconstrained(isRequired ? LABEL_REQUIRED : LABEL_OPTIONAL).toLowerCase();
+    }
+
+    public static void appendExternalDoc(StructuralNode node, ExternalDocumentation extDoc) {
+        if (extDoc == null) return;
+
+        String url = extDoc.getUrl();
+        if (StringUtils.isNotBlank(url)) {
+            Block paragraph = new ParagraphBlockImpl(node);
+            String desc = extDoc.getDescription();
+            paragraph.setSource(url + (StringUtils.isNotBlank(desc) ? "[" + desc + "]" : ""));
+            node.append(paragraph);
+        }
     }
 
     public static String superScript(String str) {

--- a/swagger2markup-swagger-v3/src/test/resources/asciidoc/petstore.adoc
+++ b/swagger2markup-swagger-v3/src/test/resources/asciidoc/petstore.adoc
@@ -42,6 +42,28 @@ All about the Users
 
 
 
+<.<|200
+
+
+<.<|This is a sample
+
+.Content
+text/plain::
++
+
+type: string
+
+.Example
+[source]
+----
+whoa!
+----
+
+
+<.<|No Links
+
+
+
 <.<|405
 
 
@@ -178,6 +200,17 @@ __optional__
 
 <.<|successful operation
 
+.Content
+application/json::
++
+
+<<_components_schemas_PetArray,PetArray>>
+
+application/xml::
++
+
+<<_components_schemas_PetArray,PetArray>>
+
 
 <.<|No Links
 
@@ -246,6 +279,17 @@ __optional__
 
 
 <.<|successful operation
+
+.Content
+application/json::
++
+
+type: array
+
+application/xml::
++
+
+type: array
 
 
 <.<|No Links
@@ -316,6 +360,17 @@ format: int64
 
 
 <.<|successful operation
+
+.Content
+application/json::
++
+
+<<_components_schemas_Pet,Pet>>
+
+application/xml::
++
+
+<<_components_schemas_Pet,Pet>>
 
 
 <.<|No Links
@@ -522,6 +577,12 @@ format: int64
 
 <.<|successful operation
 
+.Content
+application/json::
++
+
+<<_components_schemas_ApiResponse,ApiResponse>>
+
 
 <.<|No Links
 
@@ -550,6 +611,17 @@ Returns a map of status codes to quantities
 
 <.<|successful operation
 
+.Content
+application/json::
++
+
+type: object
+
+application/xml::
++
+
+type: object
+
 
 <.<|No Links
 
@@ -575,6 +647,17 @@ Returns a map of status codes to quantities
 
 
 <.<|successful operation
+
+.Content
+application/json::
++
+
+<<_components_schemas_Order,Order>>
+
+application/xml::
++
+
+<<_components_schemas_Order,Order>>
 
 
 <.<|No Links
@@ -644,6 +727,17 @@ __required__
 
 
 <.<|successful operation
+
+.Content
+application/json::
++
+
+<<_components_schemas_Order,Order>>
+
+application/xml::
++
+
+<<_components_schemas_Order,Order>>
 
 
 <.<|No Links
@@ -754,6 +848,51 @@ This can only be done by the logged in user.
 
 
 <.<|Links
+
+
+
+<.<|200
+
+
+<.<|.Content
+application/json::
++
+
+type: object
+
+.Properties
+[%header,caption=,cols=".^4a,.^16a"]
+!===
+<.<!Name
+
+<.<!Schema
+
+<.<!id
+__optional__
+
+<.<!type: string +
+format: text
+
+!===
+.Examples
+foo::
++
+.Example
+[source]
+----
+{"foo":"bar"}
+----
+
+bar::
++
+.Example
+[source]
+----
+{"bar":"baz"}
+----
+
+
+<.<|No Links
 
 
 
@@ -885,6 +1024,17 @@ __optional__
 
 <.<|successful operation
 
+.Content
+application/json::
++
+
+type: string
+
+application/xml::
++
+
+type: string
+
 
 <.<|No Links
 
@@ -977,6 +1127,17 @@ __required__
 
 
 <.<|successful operation
+
+.Content
+application/json::
++
+
+<<_components_schemas_User,User>>
+
+application/xml::
++
+
+<<_components_schemas_User,User>>
 
 
 <.<|No Links

--- a/swagger2markup-swagger-v3/src/test/resources/asciidoc/simple.adoc
+++ b/swagger2markup-swagger-v3/src/test/resources/asciidoc/simple.adoc
@@ -107,6 +107,12 @@ format: int32
 
 <.<|search results matching criteria
 
+.Content
+application/json::
++
+
+type: array
+
 
 <.<|No Links
 

--- a/swagger2markup-swagger-v3/src/test/resources/open_api/petstore.yaml
+++ b/swagger2markup-swagger-v3/src/test/resources/open_api/petstore.yaml
@@ -34,6 +34,13 @@ paths:
       description: ''
       operationId: createPet
       responses:
+        '200':
+          description: This is a sample
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: 'whoa!'
         '405':
           description: Invalid input
       security:
@@ -409,6 +416,22 @@ paths:
       description: This can only be done by the logged in user.
       operationId: createUser
       responses:
+        200:
+          content:
+            'application/json':
+              schema:
+                type: object
+                properties:
+                  id:
+                    # default is text/plain
+                    type: string
+                    format: text
+              examples:
+                foo:
+                  value: {"foo": "bar"}
+                bar:
+                  summary: A bar example
+                  value: {"bar": "baz"}
         default:
           description: successful operation
       requestBody:


### PR DESCRIPTION
#388 OpenApi 3.0 example object support

Add support for `content` object for request and responses