### PR TITLE
tests: Update swagger petstore URLs from http to https to fix failing…

### DIFF
--- a/swagger2markup/src/test/java/io/github/swagger2markup/GeneralConverterTest.java
+++ b/swagger2markup/src/test/java/io/github/swagger2markup/GeneralConverterTest.java
@@ -48,8 +48,8 @@ public class GeneralConverterTest {
         FileUtils.deleteQuietly(outputDirectory.toFile());
 
         //When
-        Swagger2MarkupConverter.from(URI.create("http://petstore.swagger.io/v2/swagger.json")).build()
-                .toFolder(outputDirectory);
+        Swagger2MarkupConverter.from(URI.create("https://petstore.swagger.io/v2/swagger.json")).build()
+            .toFolder(outputDirectory);
 
         //Then
         String[] files = outputDirectory.toFile().list();
@@ -108,8 +108,8 @@ public class GeneralConverterTest {
         FileUtils.deleteQuietly(outputDirectory.toFile());
 
         //When
-        Swagger2MarkupConverter.from(new URL("http://petstore.swagger.io/v2/swagger.json")).build()
-                .toFolder(outputDirectory);
+        Swagger2MarkupConverter.from(new URL("https://petstore.swagger.io/v2/swagger.json")).build()
+            .toFolder(outputDirectory);
 
         //Then
         String[] files = outputDirectory.toFile().list();


### PR DESCRIPTION
… tests

Accessing the http URLs was doing a 302 redirect to https.

```
> Task :swagger2markup:test

io.github.swagger2markup.GeneralConverterTest > testFromURL FAILED
    java.lang.IllegalArgumentException at GeneralConverterTest.java:111

io.github.swagger2markup.GeneralConverterTest > testFromHttpURI FAILED
    java.lang.IllegalArgumentException at GeneralConverterTest.java:51

131 tests completed, 2 failed
```