### PR TITLE
Fix Javadoc, added missing parameters and replaced with valid html

### DIFF
--- a/openapi2markup/src/main/java/io/github/swagger2markup/extension/DefinitionsDocumentExtension.java
+++ b/openapi2markup/src/main/java/io/github/swagger2markup/extension/DefinitionsDocumentExtension.java
@@ -55,6 +55,7 @@ public abstract class DefinitionsDocumentExtension extends AbstractExtension {
 
         /**
          * @param position   the current position
+         * @param document   document object
          */
         public Context(Position position, Document document) {
             super(document);
@@ -64,6 +65,7 @@ public abstract class DefinitionsDocumentExtension extends AbstractExtension {
 
         /**
          * @param position       the current position
+         * @param document       document object
          * @param definitionName the name of the current definition
          * @param model          the current Model of the definition
          */

--- a/openapi2markup/src/main/java/io/github/swagger2markup/extension/OverviewDocumentExtension.java
+++ b/openapi2markup/src/main/java/io/github/swagger2markup/extension/OverviewDocumentExtension.java
@@ -37,6 +37,7 @@ public abstract class OverviewDocumentExtension extends AbstractExtension {
 
         /**
          * @param position   the current position
+         * @param document   document object
          */
         public Context(Position position, Document document) {
             super(document);

--- a/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/BasicPathExample.java
+++ b/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/BasicPathExample.java
@@ -17,7 +17,7 @@ import static io.github.swagger2markup.internal.utils.ExamplesUtil.encodeExample
  * Date: 05/06/2020
  * Time: 01:43
  *
- * @author Klaus Schwartz <mailto:klaus@eraga.net>
+ * @author Klaus Schwartz &lt;mailto:klaus@eraga.net&gt;
  */
 public class BasicPathExample implements PathExample {
     protected final Swagger2MarkupConverter.SwaggerContext context;

--- a/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/CurlPathExample.java
+++ b/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/CurlPathExample.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * Date: 05/06/2020
  * Time: 01:44
  *
- * @author Klaus Schwartz <mailto:klaus@eraga.net>
+ * @author Klaus Schwartz &lt;mailto:klaus@eraga.net&gt;
  */
 public class CurlPathExample extends UtilityPathExample {
     /**

--- a/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/InvokeWebRequestPathExample.java
+++ b/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/InvokeWebRequestPathExample.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * Date: 05/06/2020
  * Time: 01:44
  *
- * @author Klaus Schwartz <mailto:klaus@eraga.net>
+ * @author Klaus Schwartz &lt;mailto:klaus@eraga.net&gt;
  */
 public class InvokeWebRequestPathExample extends UtilityPathExample {
     /**

--- a/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/PathExample.java
+++ b/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/PathExample.java
@@ -9,7 +9,7 @@ import io.swagger.models.parameters.Parameter;
  * Date: 05/06/2020
  * Time: 01:43
  *
- * @author Klaus Schwartz <mailto:klaus@eraga.net>
+ * @author Klaus Schwartz &lt;mailto:klaus@eraga.net&gt;
  */
 public interface PathExample {
     String getRequestString();

--- a/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/UtilityPathExample.java
+++ b/swagger2markup/src/main/java/io/github/swagger2markup/internal/utils/pathexamples/UtilityPathExample.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  * Date: 05/06/2020
  * Time: 03:34
  *
- * @author Klaus Schwartz <mailto:klaus@eraga.net>
+ * @author Klaus Schwartz &lt;mailto:klaus@eraga.net&gt;
  */
 abstract public class UtilityPathExample extends BasicPathExample {
     Logger log = LoggerFactory.getLogger(this.getClass());


### PR DESCRIPTION
Fix Javadoc, added missing parameters and replaced with valid html.
No idea how the Travis builds passed, but local builds with Oracle JDK 8 failed due to javadoc errors